### PR TITLE
fix(FEC-9214): the player stuck after pre-roll when bumper.disableMediaPreload is true

### DIFF
--- a/src/bumper-middleware.js
+++ b/src/bumper-middleware.js
@@ -31,7 +31,13 @@ class BumperMiddleware extends BaseMiddleware {
   play(next: Function): void {
     if (this._isFirstPlay) {
       this._isFirstPlay = false;
-      this._context.config.disableMediaPreload ? this._context.player.getVideoElement().load() : this._loadPlayer();
+      if (this._context.config.disableMediaPreload) {
+        if (!this._context.player.getVideoElement().src) {
+          this._context.player.getVideoElement().load();
+        }
+      } else {
+        this._loadPlayer();
+      }
     }
     switch (this._context.state) {
       case BumperState.PLAYING:


### PR DESCRIPTION
### Description of the Changes

Do not open the main video tag (https://github.com/kaltura/playkit-js-bumper/pull/5) if it already has source

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [ ] new unit / functional tests have been added (whenever applicable)
* [ ] test are passing in local environment
* [ ] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
