### PR TITLE
feat(FEC-9145): support non sibling video tags

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -37,7 +37,7 @@ module.exports = function(config) {
     client: {
       mocha: {
         reporter: 'html',
-        timeout: 50000
+        timeout: 15000
       }
     }
   };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@playkit-js/playkit-js": "0.47.0-canary.173edfb",
+    "@playkit-js/playkit-js": "0.49.0-canary.20b084c",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-eslint": "^7.1.1",
@@ -74,7 +74,7 @@
     "webpack-dev-server": "latest"
   },
   "peerDependencies": {
-    "@playkit-js/playkit-js": "0.47.0-canary.173edfb"
+    "@playkit-js/playkit-js": "0.49.0-canary.20b084c"
   },
   "repository": {
     "type": "git",

--- a/src/bumper-ads-controller.js
+++ b/src/bumper-ads-controller.js
@@ -58,7 +58,7 @@ class BumperAdsController implements IAdsPluginController {
    * @memberof BumperAdsController
    */
   get active(): boolean {
-    return this._context.adBreak;
+    return this._context.isPlayingAd();
   }
 
   /**

--- a/src/bumper-ads-controller.js
+++ b/src/bumper-ads-controller.js
@@ -47,7 +47,7 @@ class BumperAdsController implements IAdsPluginController {
    * @memberof BumperAdsController
    */
   onPlaybackEnded(): Promise<void> {
-    this._context._onPlayerEnded();
+    this._context.onPlayerEnded();
     return this._context.complete();
   }
 

--- a/src/bumper-ads-controller.js
+++ b/src/bumper-ads-controller.js
@@ -58,7 +58,7 @@ class BumperAdsController implements IAdsPluginController {
    * @memberof BumperAdsController
    */
   get active(): boolean {
-    return this._context.isPlayingAd();
+    return this._context.isAdPlaying();
   }
 
   /**

--- a/src/bumper-engine-decorator.js
+++ b/src/bumper-engine-decorator.js
@@ -16,7 +16,7 @@ class BumperEngineDecorator {
   }
 
   get active(): boolean {
-    return this._plugin.playOnMainVideoTag() && this._plugin.isPlayingAd();
+    return this._plugin.playOnMainVideoTag() && this._plugin.isAdPlaying();
   }
 
   dispatchEvent(event: FakeEvent): boolean {

--- a/src/bumper-engine-decorator.js
+++ b/src/bumper-engine-decorator.js
@@ -1,5 +1,5 @@
 // @flow
-import {BaseEngineDecorator, FakeEvent, EventType} from '@playkit-js/playkit-js';
+import {FakeEvent, EventType} from '@playkit-js/playkit-js';
 import {Bumper} from './bumper';
 
 /**
@@ -8,11 +8,10 @@ import {Bumper} from './bumper';
  * @param {IEngine} engine - The engine.
  * @param {Bumper} plugin - The bumper plugin.
  */
-class BumperEngineDecorator extends BaseEngineDecorator {
+class BumperEngineDecorator {
   _plugin: Bumper;
 
   constructor(engine: IEngine, plugin: Bumper) {
-    super(engine);
     this._plugin = plugin;
   }
 
@@ -53,7 +52,7 @@ class BumperEngineDecorator extends BaseEngineDecorator {
    * @returns {void}
    */
   set currentTime(to: number): void {
-    super.currentTime = to;
+    // Do nothing
   }
   /**
    * Get the duration in seconds.

--- a/src/bumper-engine-decorator.js
+++ b/src/bumper-engine-decorator.js
@@ -35,6 +35,17 @@ class BumperEngineDecorator {
     return true;
   }
   /**
+   * Get ended state.
+   * @returns {boolean} - The ended value of the engine.
+   * @public
+   * @override
+   * @instance
+   * @memberof BumperEngineDecorator
+   */
+  get ended(): boolean {
+    return this._plugin.adBreakPosition === -1;
+  }
+  /**
    * Get the current time in seconds.
    * @returns {number} - The current playback time.
    * @public

--- a/src/bumper-engine-decorator.js
+++ b/src/bumper-engine-decorator.js
@@ -1,0 +1,68 @@
+// @flow
+import {BaseEngineDecorator, FakeEvent, EventType} from '@playkit-js/playkit-js';
+import {Bumper} from './bumper';
+
+/**
+ * Engine decorator for bumper plugin.
+ * @class BumperEngineDecorator
+ * @param {IEngine} engine - The engine.
+ * @param {Bumper} plugin - The bumper plugin.
+ */
+class BumperEngineDecorator extends BaseEngineDecorator {
+  _plugin: Bumper;
+
+  constructor(engine: IEngine, plugin: Bumper) {
+    super(engine);
+    this._plugin = plugin;
+  }
+
+  dispatchEvent(event: FakeEvent): boolean {
+    const ignoreEvent = this._plugin.playOnMainVideoTag() && this._plugin.adBreak;
+    event.type === EventType.ENDED && this._plugin.onEnded();
+    return ignoreEvent ? event.defaultPrevented : super.dispatchEvent(event);
+  }
+  /**
+   * Get paused state.
+   * @returns {boolean} - The paused value of the engine.
+   * @public
+   * @override
+   * @instance
+   * @memberof BumperEngineDecorator
+   */
+  get paused(): boolean {
+    return (this._plugin.playOnMainVideoTag() && this._plugin.adBreak) || super.paused;
+  }
+  /**
+   * Get the current time in seconds.
+   * @returns {number} - The current playback time.
+   * @public
+   * @override
+   * @instance
+   * @memberof BumperEngineDecorator
+   */
+  get currentTime(): number {
+    return this._plugin.playOnMainVideoTag() && this._plugin.adBreak ? this._plugin.getContentTime() : super.currentTime;
+  }
+  /**
+   * Set the current time in seconds.
+   * @param {number} to - The number to set in seconds.
+   * @public
+   * @returns {void}
+   */
+  set currentTime(to: number): void {
+    super.currentTime = to;
+  }
+  /**
+   * Get the duration in seconds.
+   * @returns {number} - The playback duration.
+   * @public
+   * @override
+   * @instance
+   * @memberof BumperEngineDecorator
+   */
+  get duration(): ?number {
+    return this._plugin.playOnMainVideoTag() && this._plugin.adBreak ? this._plugin.getContentDuration() : super.duration;
+  }
+}
+
+export {BumperEngineDecorator};

--- a/src/bumper-engine-decorator.js
+++ b/src/bumper-engine-decorator.js
@@ -16,10 +16,13 @@ class BumperEngineDecorator extends BaseEngineDecorator {
     this._plugin = plugin;
   }
 
+  get active(): boolean {
+    return this._plugin.playOnMainVideoTag() && this._plugin.isPlayingAd();
+  }
+
   dispatchEvent(event: FakeEvent): boolean {
-    const ignoreEvent = this._plugin.playOnMainVideoTag() && this._plugin.adBreak;
     event.type === EventType.ENDED && this._plugin.onEnded();
-    return ignoreEvent ? event.defaultPrevented : super.dispatchEvent(event);
+    return event.defaultPrevented;
   }
   /**
    * Get paused state.
@@ -30,7 +33,7 @@ class BumperEngineDecorator extends BaseEngineDecorator {
    * @memberof BumperEngineDecorator
    */
   get paused(): boolean {
-    return (this._plugin.playOnMainVideoTag() && this._plugin.adBreak) || super.paused;
+    return true;
   }
   /**
    * Get the current time in seconds.
@@ -41,7 +44,7 @@ class BumperEngineDecorator extends BaseEngineDecorator {
    * @memberof BumperEngineDecorator
    */
   get currentTime(): number {
-    return this._plugin.playOnMainVideoTag() && this._plugin.adBreak ? this._plugin.getContentTime() : super.currentTime;
+    return this._plugin.getContentTime();
   }
   /**
    * Set the current time in seconds.
@@ -61,7 +64,7 @@ class BumperEngineDecorator extends BaseEngineDecorator {
    * @memberof BumperEngineDecorator
    */
   get duration(): ?number {
-    return this._plugin.playOnMainVideoTag() && this._plugin.adBreak ? this._plugin.getContentDuration() : super.duration;
+    return this._plugin.getContentDuration();
   }
 }
 

--- a/src/bumper-engine-decorator.js
+++ b/src/bumper-engine-decorator.js
@@ -62,7 +62,7 @@ class BumperEngineDecorator {
    * @instance
    * @memberof BumperEngineDecorator
    */
-  get duration(): ?number {
+  get duration(): number {
     return this._plugin.getContentDuration();
   }
 }

--- a/src/bumper-engine-decorator.js
+++ b/src/bumper-engine-decorator.js
@@ -7,8 +7,9 @@ import {Bumper} from './bumper';
  * @class BumperEngineDecorator
  * @param {IEngine} engine - The engine.
  * @param {Bumper} plugin - The bumper plugin.
+ * @implements {IEngineDecorator}
  */
-class BumperEngineDecorator {
+class BumperEngineDecorator implements IEngineDecorator {
   _plugin: Bumper;
 
   constructor(engine: IEngine, plugin: Bumper) {

--- a/src/bumper-middleware.js
+++ b/src/bumper-middleware.js
@@ -45,6 +45,7 @@ class BumperMiddleware extends BaseMiddleware {
       case BumperState.IDLE: {
         if (this._context.config.url && this._context.config.position.includes(0)) {
           // preroll bumper
+          this._context.initBumperCompletedPromise();
           this._context.play();
           // $FlowFixMe
           this._context.complete().finally(() => {

--- a/src/bumper-middleware.js
+++ b/src/bumper-middleware.js
@@ -29,8 +29,7 @@ class BumperMiddleware extends BaseMiddleware {
    * @returns {void}
    */
   play(next: Function): void {
-    if (this._isFirstPlay) {
-      this._isFirstPlay = false;
+    if (this._isFirstPlay && !this._context.playOnMainVideoTag()) {
       if (this._context.config.disableMediaPreload) {
         if (!this._context.player.getVideoElement().src) {
           this._context.player.getVideoElement().load();
@@ -39,6 +38,7 @@ class BumperMiddleware extends BaseMiddleware {
         this._loadPlayer();
       }
     }
+    this._isFirstPlay = false;
     switch (this._context.state) {
       case BumperState.PLAYING:
         break;

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -91,13 +91,12 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
    * Gets the engine decorator.
    * @param {IEngine} engine - The engine to decorate.
    * @public
-   * @returns {IEngine} - The ads api.
+   * @returns {IEngineDecorator} - The ads api.
    * @instance
    * @memberof Bumper
    */
-  getEngineDecorator(engine: IEngine): IEngine {
+  getEngineDecorator(engine: IEngine): IEngineDecorator {
     this._engine = engine;
-    // $FlowFixMe
     return new BumperEngineDecorator(engine, this);
   }
 

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -238,7 +238,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     return this._adBreakPosition;
   }
 
-  isPlayingAd(): boolean {
+  isAdPlaying(): boolean {
     return this._adBreak;
   }
 

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -47,7 +47,8 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     url: '',
     clickThroughUrl: '',
     position: DEFAULT_POSITION,
-    disableMediaPreload: false
+    disableMediaPreload: false,
+    playOnMainVideoTag: false
   };
 
   /**
@@ -179,8 +180,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
 
   playOnMainVideoTag(): boolean {
     return (
-      Env.os.name === 'iOS' &&
-      (!this.player.config.playback.playsinline || (this.player.isFullscreen() && !this.player.config.playback.inBrowserFullscreen))
+      this.config.playOnMainVideoTag || (Env.os.name === 'iOS' && (this.player.isFullscreen() && !this.player.config.playback.inBrowserFullscreen))
     );
   }
 

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -234,6 +234,10 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     return this._bumperState;
   }
 
+  get adBreakPosition(): number {
+    return this._adBreakPosition;
+  }
+
   isPlayingAd(): boolean {
     return this._adBreak;
   }

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -97,6 +97,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
    */
   getEngineDecorator(engine: IEngine): IEngine {
     this._engine = engine;
+    // $FlowFixMe
     return new BumperEngineDecorator(engine, this);
   }
 
@@ -329,7 +330,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     this.eventManager.listen(this.player, EventType.PLAYBACK_ENDED, () => this._onPlayerPlaybackEnded());
     this.eventManager.listen(this.player, EventType.VOLUME_CHANGE, () => this._onPlayerVolumeChange());
     this.eventManager.listen(this.player, EventType.MUTE_CHANGE, event => this._onPlayerMuteChange(event));
-    this.eventManager.listen(this.player, EventType.EXIT_FULLSCREEN, event => this._onPlayerExitFullscreen(event));
+    this.eventManager.listen(this.player, EventType.EXIT_FULLSCREEN, () => this._onPlayerExitFullscreen());
   }
 
   _onLoadStart(): void {

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -1,9 +1,24 @@
 // @flow
 // import {BaseMiddleware, BasePlugin, EngineType, Error, getCapabilities, Utils} from '@playkit-js/playkit-js';
-import {BaseMiddleware, BasePlugin, Utils, EventType, Ad, AdBreak, AdBreakType, Error, FakeEvent} from '@playkit-js/playkit-js';
+import {
+  BaseMiddleware,
+  BasePlugin,
+  BaseEngineDecorator,
+  Utils,
+  Error,
+  FakeEvent,
+  EventType,
+  Ad,
+  AdBreak,
+  AdBreakType,
+  AudioTrack,
+  TextTrack,
+  Env
+} from '@playkit-js/playkit-js';
 import {BumperMiddleware} from './bumper-middleware';
 import {BumperState} from './bumper-state';
 import {BumperAdsController} from './bumper-ads-controller';
+import {BumperEngineDecorator} from './bumper-engine-decorator';
 import './assets/style.css';
 
 const BUMPER_CONTAINER_CLASS: string = 'playkit-bumper-container';
@@ -52,6 +67,12 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   _adBreak: boolean;
   _adBreakPosition: number;
   _bumperState: string;
+  _engine: IEngine;
+  _contentSrc: string;
+  _contentCurrentTime: number;
+  _contentDuration: number;
+  _selectedAudioTrack: AudioTrack;
+  _selectedTextTrack: TextTrack;
 
   /**
    * @constructor
@@ -64,6 +85,19 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     this._initBumperContainer();
     this._initMembers();
     this._addBindings();
+  }
+
+  /**
+   * Gets the engine decorator.
+   * @param {IEngine} engine - The engine to decorate.
+   * @public
+   * @returns {BaseEngineDecorator} - The ads api.
+   * @instance
+   * @memberof Bumper
+   */
+  getEngineDecorator(engine: IEngine): BaseEngineDecorator {
+    this._engine = engine;
+    return new BumperEngineDecorator(engine, this);
   }
 
   /**
@@ -82,7 +116,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
    * @public
    * @returns {IAdsPluginController} - The ads api.
    * @instance
-   * @memberof Ima
+   * @memberof Bumper
    */
   getAdsController(): IAdsPluginController {
     return new BumperAdsController(this);
@@ -99,7 +133,8 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     if (this._bumperState === BumperState.IDLE) {
       this._load();
     }
-    this._bumperVideoElement.play();
+    this._adBreak = true;
+    this.playOnMainVideoTag() ? this._engine.play() : this._bumperVideoElement.play();
     this._hideElement(this._bumperCoverDiv);
   }
 
@@ -111,7 +146,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
    * @memberof Bumper
    */
   pause(): void {
-    this._bumperVideoElement.pause();
+    this.playOnMainVideoTag() ? this._engine.pause() : this._bumperVideoElement.pause();
   }
 
   /**
@@ -140,6 +175,58 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     Utils.Dom.removeAttribute(this._bumperVideoElement, 'src');
     this._initMembers();
     this._addBindings();
+  }
+
+  playOnMainVideoTag(): boolean {
+    return (
+      Env.os.name === 'iOS' &&
+      (!this.player.config.playback.playsinline || (this.player.isFullscreen() && !this.player.config.playback.inBrowserFullscreen))
+    );
+  }
+
+  getContentTime(): number {
+    return this._contentCurrentTime;
+  }
+
+  getContentDuration(): number {
+    return this._contentDuration;
+  }
+
+  loadMedia(): void {
+    if (this.config.url) {
+      this.dispatchEvent(EventType.AD_MANIFEST_LOADED, {adBreaksPosition: this.config.position});
+    }
+  }
+
+  onEnded(): void {
+    if (this._adBreak) {
+      this._state = BumperState.LOADED;
+      this._adBreak = false;
+      this._hideElement(this._bumperContainerDiv);
+      this.dispatchEvent(EventType.AD_COMPLETED);
+      this.dispatchEvent(EventType.AD_BREAK_END);
+      if (!this.config.position.includes(-1) || this._adBreakPosition === -1) {
+        this._state = BumperState.DONE;
+        this.dispatchEvent(EventType.ADS_COMPLETED);
+        if (this.playOnMainVideoTag()) {
+          this.logger.debug('Switch source to content url');
+          this.eventManager.listenOnce(this._engine, EventType.PLAYING, () => {
+            this.player.selectTrack(this._selectedAudioTrack);
+            this.player.selectTrack(this._selectedTextTrack);
+          });
+          this.player.getVideoElement().src = this._contentSrc;
+        }
+      }
+    }
+  }
+
+  onPlayerEnded(): void {
+    if (this._bumperState !== BumperState.DONE) {
+      this._adBreakPosition = -1;
+      this._initBumperCompletedPromise();
+      this.playOnMainVideoTag() && (this._state = BumperState.IDLE);
+      this.play();
+    }
   }
 
   set _state(newState: string) {
@@ -195,6 +282,11 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     this._validatePosition();
     this._adBreakPosition = this.config.position[0];
     this.config.clickThroughUrl && (this._bumperClickThroughDiv.href = this.config.clickThroughUrl);
+    this._contentSrc = '';
+    this._contentCurrentTime = 0;
+    this._contentDuration = NaN;
+    this._selectedAudioTrack = null;
+    this._selectedTextTrack = null;
     this._state = BumperState.IDLE;
     this._initBumperCompletedPromise();
   }
@@ -207,9 +299,22 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   }
 
   _initBumperCompletedPromise(): void {
+    this.logger.debug('Init bumper complete promise');
     this._bumperCompletedPromise = new Promise((resolve, reject) => {
-      this.eventManager.listenOnce(this._bumperVideoElement, EventType.ENDED, resolve);
-      this.eventManager.listenOnce(this._bumperVideoElement, EventType.ERROR, reject);
+      if (this.playOnMainVideoTag()) {
+        if (this._engine) {
+          this.eventManager.listenOnce(this._engine, EventType.ENDED, resolve);
+          this.eventManager.listenOnce(this._engine, EventType.ERROR, reject);
+        } else {
+          this.eventManager.listenOnce(this.player, EventType.SOURCE_SELECTED, () => {
+            this.eventManager.listenOnce(this._engine, EventType.ENDED, resolve);
+            this.eventManager.listenOnce(this._engine, EventType.ERROR, reject);
+          });
+        }
+      } else {
+        this.eventManager.listenOnce(this._bumperVideoElement, EventType.ENDED, resolve);
+        this.eventManager.listenOnce(this._bumperVideoElement, EventType.ERROR, reject);
+      }
     }).catch(() => {
       // silence the promise rejection, error is handled by the ad error event
     });
@@ -220,36 +325,40 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     this.eventManager.listen(this._bumperVideoElement, EventType.LOADED_DATA, () => this._onLoadedData());
     this.eventManager.listen(this._bumperVideoElement, EventType.PLAYING, () => this._onPlaying());
     this.eventManager.listen(this._bumperVideoElement, EventType.PAUSE, () => this._onPause());
-    this.eventManager.listen(this._bumperVideoElement, EventType.ENDED, () => this._onEnded());
+    this.eventManager.listen(this._bumperVideoElement, EventType.ENDED, () => this.onEnded());
     this.eventManager.listen(this._bumperVideoElement, EventType.TIME_UPDATE, () => this._onTimeUpdate());
     this.eventManager.listen(this._bumperVideoElement, EventType.ERROR, () => this._onError());
     this.eventManager.listen(this._bumperVideoElement, EventType.WAITING, () => this._onWaiting());
     this.eventManager.listen(this._bumperVideoElement, EventType.VOLUME_CHANGE, () => this._onVolumeChange());
+    this.eventManager.listen(this.player, EventType.SOURCE_SELECTED, () => this._onPlayerSourceSelected());
     this.eventManager.listen(this.player, EventType.PLAYBACK_START, () => this._onPlayerPlaybackStart());
     this.eventManager.listen(this.player, EventType.VOLUME_CHANGE, () => this._onPlayerVolumeChange());
     this.eventManager.listen(this.player, EventType.MUTE_CHANGE, event => this._onPlayerMuteChange(event));
   }
 
   _onLoadStart(): void {
-    this._state = BumperState.LOADING;
+    this._adBreak && (this._state = BumperState.LOADING);
   }
 
   _onLoadedData(): void {
-    this._state = BumperState.LOADED;
-    this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
+    if (this._adBreak) {
+      this._state = BumperState.LOADED;
+      this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
+    }
   }
 
   _onPlaying(): void {
-    if (this._bumperState === BumperState.LOADED) {
-      this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
-      this.dispatchEvent(EventType.AD_STARTED, {ad: this._getAd()});
-      this._adBreak = true;
+    if (this._adBreak) {
+      if (this._bumperState === BumperState.LOADED) {
+        this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
+        this.dispatchEvent(EventType.AD_STARTED, {ad: this._getAd()});
+      }
+      if (this._bumperState === BumperState.PAUSED) {
+        this.dispatchEvent(EventType.AD_RESUMED);
+      }
+      this._state = BumperState.PLAYING;
+      this._showElement(this._bumperContainerDiv);
     }
-    if (this._bumperState === BumperState.PAUSED) {
-      this.dispatchEvent(EventType.AD_RESUMED);
-    }
-    this._state = BumperState.PLAYING;
-    this._showElement(this._bumperContainerDiv);
   }
 
   _onPause(): void {
@@ -259,45 +368,42 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     }
   }
 
-  _onEnded(): void {
-    this._state = BumperState.LOADED;
-    this._adBreak = false;
-    this._hideElement(this._bumperContainerDiv);
-    this.dispatchEvent(EventType.AD_COMPLETED);
-    this.dispatchEvent(EventType.AD_BREAK_END);
-    if (!this.config.position.includes(-1) || this._adBreakPosition === -1) {
-      this._state = BumperState.DONE;
-      this.dispatchEvent(EventType.ADS_COMPLETED);
-    }
-  }
-
   _onTimeUpdate(): void {
-    this.dispatchEvent(EventType.AD_PROGRESS, {
-      adProgress: {
-        currentTime: this._bumperVideoElement.currentTime,
-        duration: this._bumperVideoElement.duration
-      }
-    });
+    this._adBreak &&
+      this.dispatchEvent(EventType.AD_PROGRESS, {
+        adProgress: {
+          currentTime: this.playOnMainVideoTag() ? this._engine.currentTime : this._bumperVideoElement.currentTime,
+          duration: this.playOnMainVideoTag() ? this._engine.duration : this._bumperVideoElement.duration
+        }
+      });
   }
 
   _onError(): void {
-    this._state = BumperState.DONE;
-    this.dispatchEvent(EventType.AD_ERROR, this._getAdError());
-  }
-
-  _onWaiting(): void {
-    this.dispatchEvent(EventType.AD_BUFFERING);
-  }
-
-  _onVolumeChange(): void {
     if (this._adBreak) {
-      this.dispatchEvent(EventType.AD_VOLUME_CHANGED);
+      this._adBreak = false;
+      this._state = BumperState.DONE;
+      this.dispatchEvent(EventType.AD_ERROR, this._getAdError());
     }
   }
 
-  loadMedia(): void {
-    if (this.config.url) {
-      this.dispatchEvent(EventType.AD_MANIFEST_LOADED, {adBreaksPosition: this.config.position});
+  _onWaiting(): void {
+    this._adBreak && this.dispatchEvent(EventType.AD_BUFFERING);
+  }
+
+  _onVolumeChange(): void {
+    this._adBreak && this.dispatchEvent(EventType.AD_VOLUME_CHANGED);
+  }
+
+  _onPlayerSourceSelected(): void {
+    if (this.playOnMainVideoTag()) {
+      this.eventManager.listen(this._engine, EventType.LOAD_START, () => this._onLoadStart());
+      this.eventManager.listen(this._engine, EventType.LOADED_DATA, () => this._onLoadedData());
+      this.eventManager.listen(this._engine, EventType.PLAYING, () => this._onPlaying());
+      this.eventManager.listen(this._engine, EventType.PAUSE, () => this._onPause());
+      this.eventManager.listen(this._engine, EventType.TIME_UPDATE, () => this._onTimeUpdate());
+      this.eventManager.listen(this._engine, EventType.ERROR, () => this._onError());
+      this.eventManager.listen(this._engine, EventType.WAITING, () => this._onWaiting());
+      this.eventManager.listen(this._engine, EventType.VOLUME_CHANGE, () => this._onVolumeChange());
     }
   }
 
@@ -313,14 +419,6 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     this._syncPlayerVolume();
     if (this._adBreak) {
       event.payload.mute && this.dispatchEvent(EventType.AD_MUTED);
-    }
-  }
-
-  _onPlayerEnded(): void {
-    if (this._bumperState !== BumperState.DONE) {
-      this._adBreakPosition = -1;
-      this._initBumperCompletedPromise();
-      this.play();
     }
   }
 
@@ -342,8 +440,18 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   }
 
   _load(): void {
-    this._bumperVideoElement.src = this.config.url;
-    this._bumperVideoElement.setAttribute('playsinline', '');
+    if (this.playOnMainVideoTag()) {
+      this.logger.debug('Switch source to bumper url');
+      this._contentSrc = this._engine.src;
+      this._contentCurrentTime = this._engine.currentTime;
+      this._contentDuration = this._engine.duration;
+      this._selectedAudioTrack = this.player.getActiveTracks().audio;
+      this._selectedTextTrack = this.player.getActiveTracks().text;
+      this.player.getVideoElement().src = this.config.url;
+    } else {
+      this._bumperVideoElement.src = this.config.url;
+      this._bumperVideoElement.setAttribute('playsinline', '');
+    }
   }
 
   _getAd(): Ad {

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -131,7 +131,6 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
    */
   play(): void {
     if (this._bumperState === BumperState.IDLE) {
-      this._initBumperCompletedPromise();
       this._load();
     }
     this._adBreak = true;
@@ -220,6 +219,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     if (this._bumperState !== BumperState.DONE) {
       this._adBreakPosition = -1;
       this.playOnMainVideoTag() && (this._state = BumperState.IDLE);
+      this.initBumperCompletedPromise();
       this.play();
     }
   }
@@ -292,7 +292,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     }
   }
 
-  _initBumperCompletedPromise(): void {
+  initBumperCompletedPromise(): void {
     this.logger.debug('Init bumper complete promise');
     this._bumperCompletedPromise = new Promise((resolve, reject) => {
       if (this.playOnMainVideoTag()) {

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -306,10 +306,9 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
             this.eventManager.listenOnce(this._engine, EventType.ERROR, reject);
           });
         }
-      } else {
-        this.eventManager.listenOnce(this._bumperVideoElement, EventType.ENDED, resolve);
-        this.eventManager.listenOnce(this._bumperVideoElement, EventType.ERROR, reject);
       }
+      this.eventManager.listenOnce(this._bumperVideoElement, EventType.ENDED, resolve);
+      this.eventManager.listenOnce(this._bumperVideoElement, EventType.ERROR, reject);
     }).catch(() => {
       // silence the promise rejection, error is handled by the ad error event
     });

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -1,5 +1,99 @@
+import {loadPlayer, EventManager} from '@playkit-js/playkit-js';
+// eslint-disable-next-line no-unused-vars
+import bumper from '../../src';
+
+const BUMPER_URL =
+  'http://qa-apache-php7.dev.kaltura.com/p/1091/sp/109100/serveFlavor/entryId/0_6r7gufsj/v/2/ev/4/flavorId/0_1c7nsvq6/forceproxy/true/name/a.mp4';
 describe('Bumper', () => {
-  it('should return true', () => {
-    return true;
+  describe('Sibling video tags', () => {
+    function validateAdParams(event) {
+      event.payload.ad.bumper.should.be.true;
+      event.payload.ad.id.should.equal('1234');
+      event.payload.ad.clickThroughUrl.should.equal('some/url');
+      event.payload.ad.url.should.equal(BUMPER_URL);
+    }
+    function validateAdBreakParams(event, isPreroll) {
+      event.payload.adBreak.numAds.should.equal(1);
+      isPreroll ? event.payload.adBreak.position.should.equal(0) : event.payload.adBreak.position.should.equal(-1);
+      isPreroll ? event.payload.adBreak.type.should.equal('preroll') : event.payload.adBreak.type.should.equal('postroll');
+    }
+    let player;
+    const eventManager = new EventManager();
+    after(() => {
+      player.destroy();
+    });
+    it('should play pre and post bumper and fire events', done => {
+      const config = {
+        plugins: {
+          bumper: {
+            id: '1234',
+            clickThroughUrl: 'some/url',
+            url: BUMPER_URL
+          }
+        }
+      };
+      player = loadPlayer(config);
+      eventManager.listenOnce(player, player.Event.AD_MANIFEST_LOADED, event => {
+        event.payload.adBreaksPosition.should.deep.equal([0, -1]);
+        eventManager.listenOnce(player, player.Event.AD_LOADED, event => {
+          validateAdParams(event);
+          eventManager.listenOnce(player, player.Event.AD_BREAK_START, event => {
+            validateAdBreakParams(event, true);
+            eventManager.listenOnce(player, player.Event.AD_STARTED, event => {
+              validateAdParams(event);
+              eventManager.listenOnce(player, player.Event.AD_PROGRESS, () => {
+                eventManager.listenOnce(player, player.Event.AD_PAUSED, () => {
+                  eventManager.listenOnce(player, player.Event.AD_RESUMED, () => {
+                    eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
+                      eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
+                        eventManager.listenOnce(player, player.Event.PLAYING, () => {
+                          eventManager.listenOnce(player, player.Event.ENDED, () => {
+                            eventManager.listenOnce(player, player.Event.AD_BREAK_START, event => {
+                              validateAdBreakParams(event, false);
+                              eventManager.listenOnce(player, player.Event.AD_STARTED, event => {
+                                validateAdParams(event);
+                                eventManager.listenOnce(player, player.Event.AD_PROGRESS, () => {
+                                  eventManager.listenOnce(player, player.Event.AD_PAUSED, () => {
+                                    eventManager.listenOnce(player, player.Event.AD_RESUMED, () => {
+                                      eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
+                                        eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
+                                          eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+                                            done();
+                                          });
+                                        });
+                                      });
+                                    });
+                                    player.play();
+                                  });
+                                  player.pause();
+                                });
+                              });
+                            });
+                          });
+                          player.currentTime = player.duration;
+                        });
+                      });
+                    });
+                  });
+                  player.play();
+                });
+                player.pause();
+              });
+            });
+          });
+        });
+      });
+      player.configure({
+        sources: {
+          progressive: [
+            {
+              mimetype: 'video/mp4',
+              url: 'http://www.html5videoplayer.net/videos/toystory.mp4'
+            }
+          ]
+        }
+      });
+      player.play();
+    });
   });
 });

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -1,37 +1,50 @@
-import {loadPlayer, EventManager} from '@playkit-js/playkit-js';
+import {loadPlayer, EventManager, Utils} from '@playkit-js/playkit-js';
 // eslint-disable-next-line no-unused-vars
 import bumper from '../../src';
 
 const BUMPER_URL =
-  'http://qa-apache-php7.dev.kaltura.com/p/1091/sp/109100/serveFlavor/entryId/0_6r7gufsj/v/2/ev/4/flavorId/0_1c7nsvq6/forceproxy/true/name/a.mp4';
+    'http://qa-apache-php7.dev.kaltura.com/p/1091/sp/109100/serveFlavor/entryId/0_6r7gufsj/v/2/ev/4/flavorId/0_1c7nsvq6/forceproxy/true/name/a.mp4',
+  config = {
+    plugins: {
+      bumper: {
+        id: '1234',
+        clickThroughUrl: 'some/url',
+        url: BUMPER_URL
+      }
+    }
+  },
+  sources = {
+    progressive: [
+      {
+        mimetype: 'video/mp4',
+        url: 'http://www.html5videoplayer.net/videos/toystory.mp4'
+      }
+    ]
+  };
+
+function validateAdParams(event) {
+  event.payload.ad.bumper.should.be.true;
+  event.payload.ad.id.should.equal('1234');
+  event.payload.ad.clickThroughUrl.should.equal('some/url');
+  event.payload.ad.url.should.equal(BUMPER_URL);
+}
+function validateAdBreakParams(event, isPreroll) {
+  event.payload.adBreak.numAds.should.equal(1);
+  isPreroll ? event.payload.adBreak.position.should.equal(0) : event.payload.adBreak.position.should.equal(-1);
+  isPreroll ? event.payload.adBreak.type.should.equal('preroll') : event.payload.adBreak.type.should.equal('postroll');
+}
+
 describe('Bumper', () => {
   describe('Sibling video tags', () => {
-    function validateAdParams(event) {
-      event.payload.ad.bumper.should.be.true;
-      event.payload.ad.id.should.equal('1234');
-      event.payload.ad.clickThroughUrl.should.equal('some/url');
-      event.payload.ad.url.should.equal(BUMPER_URL);
-    }
-    function validateAdBreakParams(event, isPreroll) {
-      event.payload.adBreak.numAds.should.equal(1);
-      isPreroll ? event.payload.adBreak.position.should.equal(0) : event.payload.adBreak.position.should.equal(-1);
-      isPreroll ? event.payload.adBreak.type.should.equal('preroll') : event.payload.adBreak.type.should.equal('postroll');
-    }
-    let player;
-    const eventManager = new EventManager();
-    after(() => {
+    let player, eventManager;
+    beforeEach(() => {
+      eventManager = new EventManager();
+    });
+    afterEach(() => {
       player.destroy();
+      eventManager.destroy();
     });
     it('should play pre and post bumper and fire events', done => {
-      const config = {
-        plugins: {
-          bumper: {
-            id: '1234',
-            clickThroughUrl: 'some/url',
-            url: BUMPER_URL
-          }
-        }
-      };
       player = loadPlayer(config);
       eventManager.listenOnce(player, player.Event.AD_MANIFEST_LOADED, event => {
         event.payload.adBreaksPosition.should.deep.equal([0, -1]);
@@ -41,7 +54,9 @@ describe('Bumper', () => {
             validateAdBreakParams(event, true);
             eventManager.listenOnce(player, player.Event.AD_STARTED, event => {
               validateAdParams(event);
-              eventManager.listenOnce(player, player.Event.AD_PROGRESS, () => {
+              eventManager.listenOnce(player, player.Event.AD_PROGRESS, event => {
+                event.payload.adProgress.currentTime.should.exists;
+                event.payload.adProgress.duration.should.exists;
                 eventManager.listenOnce(player, player.Event.AD_PAUSED, () => {
                   eventManager.listenOnce(player, player.Event.AD_RESUMED, () => {
                     eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
@@ -83,15 +98,57 @@ describe('Bumper', () => {
           });
         });
       });
-      player.configure({
-        sources: {
-          progressive: [
-            {
-              mimetype: 'video/mp4',
-              url: 'http://www.html5videoplayer.net/videos/toystory.mp4'
+      player.configure({sources});
+      player.play();
+    });
+
+    it('should play pre roll only', done => {
+      player = loadPlayer(
+        Utils.Object.mergeDeep(config, {
+          plugins: {
+            bumper: {
+              position: [0]
             }
-          ]
-        }
+          }
+        })
+      );
+      eventManager.listenOnce(player, player.Event.AD_MANIFEST_LOADED, event => {
+        event.payload.adBreaksPosition.should.deep.equal([0]);
+        eventManager.listenOnce(player, player.Event.AD_BREAK_START, event => {
+          validateAdBreakParams(event, true);
+          eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+            eventManager.listenOnce(player, player.Event.FIRST_PLAY, () => {
+              done();
+            });
+          });
+        });
+      });
+      player.configure({sources});
+      player.play();
+    });
+
+    it('should play post roll only', done => {
+      player = loadPlayer(
+        Utils.Object.mergeDeep(config, {
+          plugins: {
+            bumper: {
+              position: [-1]
+            }
+          }
+        })
+      );
+      eventManager.listenOnce(player, player.Event.AD_MANIFEST_LOADED, event => {
+        event.payload.adBreaksPosition.should.deep.equal([-1]);
+        eventManager.listenOnce(player, player.Event.AD_BREAK_START, event => {
+          validateAdBreakParams(event, false);
+          eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+            done();
+          });
+        });
+      });
+      player.configure({sources});
+      eventManager.listenOnce(player, player.Event.PLAYING, () => {
+        player.currentTime = player.duration;
       });
       player.play();
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@playkit-js/playkit-js@0.47.0-canary.173edfb":
-  version "0.47.0-canary.173edfb"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.47.0-canary.173edfb.tgz#de7dcea8d9d0f38e6764ab6c4d7b2b55a53cb209"
+"@playkit-js/playkit-js@0.49.0-canary.20b084c":
+  version "0.49.0-canary.20b084c"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.49.0-canary.20b084c.tgz#c49685e6627029de39b8ababacf5a0c5ef5f184d"
   dependencies:
     js-logger "^1.3.0"
     ua-parser-js "^0.7.13"


### PR DESCRIPTION
### Description of the Changes

* Expose `BumperEngineDecorator` according to https://github.com/kaltura/playkit-js/pull/369
* Handle playing the bumper on the main video tag 
* add a new config `playOnMainVideoTag`

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [x] new unit / functional tests have been added (whenever applicable)
* [x] test are passing in local environment
* [x] Travis tests are passing (or test results are not worse than on master branch :))
* [x] Docs have been updated
