### PR TITLE
fix(FEC-9228): the bumper failed to be play correctly when bootstrap library using for the player

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -15,6 +15,7 @@
   visibility: hidden;
   position: absolute;
   width: 100%;
+  min-height: 100%;
 }
 
 .playkit-fullscreen .playkit-bumper-container {


### PR DESCRIPTION
### Description of the Changes

set `min-height: 100%` (see https://github.com/kaltura/playkit-js-bumper/pull/6)  

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [ ] new unit / functional tests have been added (whenever applicable)
* [ ] test are passing in local environment
* [ ] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
