### PR TITLE
fix: playback rate returns to default after bumper

### DIFF
--- a/src/bumper.js
+++ b/src/bumper.js
@@ -74,6 +74,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   _contentDuration: number;
   _selectedAudioTrack: AudioTrack;
   _selectedTextTrack: TextTrack;
+  _selectedPlaybackRate: number;
 
   /**
    * @constructor
@@ -286,6 +287,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     this._contentDuration = NaN;
     this._selectedAudioTrack = null;
     this._selectedTextTrack = null;
+    this._selectedPlaybackRate = 1;
     this._state = BumperState.IDLE;
   }
 
@@ -424,6 +426,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
       this.eventManager.listenOnce(this._engine, EventType.PLAYING, () => {
         this.player.selectTrack(this._selectedAudioTrack);
         this.player.selectTrack(this._selectedTextTrack);
+        this.player.playbackRate = this._selectedPlaybackRate;
       });
       this.player.getVideoElement().src = this._contentSrc;
       this._contentSrc = '';
@@ -472,6 +475,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
       this._contentDuration = this._engine.duration;
       this._selectedAudioTrack = this.player.getActiveTracks().audio;
       this._selectedTextTrack = this.player.getActiveTracks().text;
+      this._selectedPlaybackRate = this.player.playbackRate;
       this.player.getVideoElement().src = this.config.url;
     } else {
       this._bumperVideoElement.src = this.config.url;


### PR DESCRIPTION
### Description of the Changes

save the rate before switching to bumper and restore after

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [ ] new unit / functional tests have been added (whenever applicable)
* [ ] test are passing in local environment
* [ ] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
