### PR TITLE
fix(FEC-9250): when a wrong bumper url is configured, no replay icon is displayed in the end of the video

### DIFF
--- a/src/bumper.js
+++ b/src/bumper.js
@@ -220,10 +220,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
       if (this._adBreakPosition === 0) {
         this._maybeSwitchToContent();
       }
-      if (!this.config.position.includes(-1) || this._adBreakPosition === -1) {
-        this._state = BumperState.DONE;
-        this.dispatchEvent(EventType.ADS_COMPLETED);
-      }
+      this._maybeDispatchAdsCompleted();
     }
   }
 
@@ -380,10 +377,11 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   }
 
   _onError(): void {
-    if (this._adBreak) {
+    if (this._adBreak || this._bumperState === BumperState.LOADING) {
       this._adBreak = false;
-      this._state = BumperState.DONE;
+      this._state = BumperState.IDLE;
       this.dispatchEvent(EventType.AD_ERROR, this._getAdError());
+      this._maybeDispatchAdsCompleted();
     }
   }
 
@@ -426,6 +424,13 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
       });
       this.player.getVideoElement().src = this._contentSrc;
       this._contentSrc = '';
+    }
+  }
+
+  _maybeDispatchAdsCompleted(): void {
+    if (!this.config.position.includes(-1) || this._adBreakPosition === -1) {
+      this._state = BumperState.DONE;
+      this.dispatchEvent(EventType.ADS_COMPLETED);
     }
   }
 

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -338,6 +338,90 @@ describe('Bumper', () => {
       player.plugins.bumper.config.position.should.deep.equal([0, -1]);
       player.plugins.bumper._adBreakPosition.should.equal(0);
     });
+
+    it('Should handle invalid bumper url', done => {
+      eventManager.listenOnce(player, player.Event.PLAYING, () => {
+        eventManager.listenOnce(player, player.Event.PLAYBACK_ENDED, () => {
+          done();
+        });
+        player.currentTime = player.duration;
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            url: 'some/invalid/url'
+          }
+        },
+        sources
+      });
+      player.play();
+    });
+
+    it('Should handle invalid pre bumper url', done => {
+      eventManager.listenOnce(player, player.Event.PLAYING, () => {
+        eventManager.listenOnce(player, player.Event.PLAYBACK_ENDED, () => {
+          done();
+        });
+        player.currentTime = player.duration;
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            position: [0],
+            url: 'some/invalid/url'
+          }
+        },
+        sources
+      });
+      player.play();
+    });
+
+    it('Should handle invalid post bumper url', done => {
+      eventManager.listenOnce(player, player.Event.PLAYING, () => {
+        eventManager.listenOnce(player, player.Event.PLAYBACK_ENDED, () => {
+          done();
+        });
+        player.currentTime = player.duration;
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            position: [-1],
+            url: 'some/invalid/url'
+          }
+        },
+        sources
+      });
+      player.play();
+    });
+
+    it('Should play post bumper even the pre bumper is failed', done => {
+      eventManager.listenOnce(player, player.Event.AD_ERROR, () => {
+        eventManager.listenOnce(player, player.Event.PLAYING, () => {
+          eventManager.listenOnce(player, player.Event.AD_STARTED, event => {
+            validateAdParams(event, true);
+            done();
+          });
+          player.configure({
+            plugins: {
+              bumper: {
+                url: BUMPER_URL
+              }
+            }
+          });
+          player.currentTime = player.duration;
+        });
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            url: 'some/invalid/url'
+          }
+        },
+        sources
+      });
+      player.play();
+    });
   });
 
   describe('Non sibling video tags', () => {
@@ -376,7 +460,9 @@ describe('Bumper', () => {
                                       eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
                                         eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
                                           eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
-                                            done();
+                                            eventManager.listenOnce(player, player.Event.PLAYBACK_ENDED, () => {
+                                              done();
+                                            });
                                           });
                                         });
                                       });
@@ -590,6 +676,90 @@ describe('Bumper', () => {
         sources
       });
       setTimeout(() => player.play(), 1000);
+    });
+
+    it('Should handle invalid bumper url', done => {
+      eventManager.listenOnce(player, player.Event.PLAYING, () => {
+        eventManager.listenOnce(player, player.Event.PLAYBACK_ENDED, () => {
+          done();
+        });
+        player.currentTime = player.duration;
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            url: 'some/invalid/url'
+          }
+        },
+        sources
+      });
+      player.play();
+    });
+
+    it('Should handle invalid pre bumper url', done => {
+      eventManager.listenOnce(player, player.Event.PLAYING, () => {
+        eventManager.listenOnce(player, player.Event.PLAYBACK_ENDED, () => {
+          done();
+        });
+        player.currentTime = player.duration;
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            position: [0],
+            url: 'some/invalid/url'
+          }
+        },
+        sources
+      });
+      player.play();
+    });
+
+    it('Should handle invalid post bumper url', done => {
+      eventManager.listenOnce(player, player.Event.PLAYING, () => {
+        eventManager.listenOnce(player, player.Event.PLAYBACK_ENDED, () => {
+          done();
+        });
+        player.currentTime = player.duration;
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            position: [-1],
+            url: 'some/invalid/url'
+          }
+        },
+        sources
+      });
+      player.play();
+    });
+
+    it('Should play post bumper even the pre bumper is failed', done => {
+      eventManager.listenOnce(player, player.Event.AD_ERROR, () => {
+        eventManager.listenOnce(player, player.Event.PLAYING, () => {
+          eventManager.listenOnce(player, player.Event.AD_STARTED, event => {
+            validateAdParams(event, true);
+            done();
+          });
+          player.configure({
+            plugins: {
+              bumper: {
+                url: BUMPER_URL
+              }
+            }
+          });
+          player.currentTime = player.duration;
+        });
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            url: 'some/invalid/url'
+          }
+        },
+        sources
+      });
+      player.play();
     });
   });
 });


### PR DESCRIPTION
### Description of the Changes

* Fire `ADS_COMPLETED` even the ad is failed (like ima does)
* Move to `IDLE` on error to get chance play post bumper even the pre bumper failed 

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [x] new unit / functional tests have been added (whenever applicable)
* [x] test are passing in local environment
* [x] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
