### PR TITLE
fix(FEC-9255): the playback started during pre-bumper

### DIFF
--- a/src/bumper-middleware.js
+++ b/src/bumper-middleware.js
@@ -63,7 +63,7 @@ class BumperMiddleware extends BaseMiddleware {
       case BumperState.IDLE:
       case BumperState.LOADING:
       case BumperState.LOADED: {
-        if (this._isFirstPlay && this._context.config.url && this._context.config.position.includes(0)) {
+        if (this._context.config.url && this._context.adBreakPosition === 0) {
           // preroll bumper
           this._context.initBumperCompletedPromise();
           this._context.play();

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -221,12 +221,12 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
         this._maybeSwitchToContent();
       }
       this._maybeDispatchAdsCompleted();
+      this._adBreakPosition = -1;
     }
   }
 
   onPlayerEnded(): void {
     if (this._bumperState !== BumperState.DONE) {
-      this._adBreakPosition = -1;
       this.playOnMainVideoTag() && (this._state = BumperState.IDLE);
       this.initBumperCompletedPromise();
       this.play();
@@ -382,6 +382,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
       this._state = BumperState.IDLE;
       this.dispatchEvent(EventType.AD_ERROR, this._getAdError());
       this._maybeDispatchAdsCompleted();
+      this._adBreakPosition = -1;
     }
   }
 
@@ -400,10 +401,6 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     this.eventManager.listen(this._videoElement, EventType.ERROR, () => this._onError());
     this.eventManager.listen(this._videoElement, EventType.WAITING, () => this._onWaiting());
     this.eventManager.listen(this._videoElement, EventType.VOLUME_CHANGE, () => this._onVolumeChange());
-    if (this.config.preload && (this._adBreakPosition === 0 || !this.playOnMainVideoTag())) {
-      this.logger.debug('Preload the bumper');
-      this.load();
-    }
   }
 
   _onPlayerPlaybackStart(): void {

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -234,10 +234,8 @@ describe('Bumper', () => {
         done();
       });
       player.configure({
-        plugins: {
-          bumper: {
-            preload: true
-          }
+        playback: {
+          preload: 'auto'
         },
         sources
       });
@@ -249,10 +247,12 @@ describe('Bumper', () => {
         done();
       });
       player.configure({
+        playback: {
+          preload: 'auto'
+        },
         plugins: {
           bumper: {
-            position: [-1],
-            preload: true
+            position: [-1]
           }
         },
         sources
@@ -300,10 +300,8 @@ describe('Bumper', () => {
         player.currentTime = player.duration;
       });
       player.configure({
-        plugins: {
-          bumper: {
-            preload: true
-          }
+        playback: {
+          preload: 'auto'
         },
         sources
       });
@@ -420,6 +418,17 @@ describe('Bumper', () => {
         },
         sources
       });
+      player.play();
+    });
+
+    it('Should call to player play after pre bumper finish', done => {
+      eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
+        eventManager.listenOnce(player, player.Event.PLAY, () => {
+          done();
+        });
+      });
+      player.configure({sources});
+      player.play();
       player.play();
     });
   });
@@ -602,10 +611,8 @@ describe('Bumper', () => {
         done();
       });
       player.configure({
-        plugins: {
-          bumper: {
-            preload: true
-          }
+        playback: {
+          preload: 'auto'
         },
         sources
       });
@@ -616,10 +623,12 @@ describe('Bumper', () => {
         done(new Error('Should not pre load the post bumper when playing on the main video tag'));
       });
       player.configure({
+        playback: {
+          preload: 'auto'
+        },
         plugins: {
           bumper: {
-            position: [-1],
-            preload: true
+            position: [-1]
           }
         },
         sources
@@ -668,10 +677,8 @@ describe('Bumper', () => {
         player.currentTime = player.duration;
       });
       player.configure({
-        plugins: {
-          bumper: {
-            preload: true
-          }
+        playback: {
+          preload: 'auto'
         },
         sources
       });


### PR DESCRIPTION
### Description of the Changes

**The issue:** When the `play` api called more than once (e.g in this ticket- from user and [ima](https://github.com/kaltura/playkit-js-ima/blob/551a2fc6286162fd9d534be69534268d0cc07755/src/ima-state-machine.js#L319)), the second `play` called to the player.
**Solution:** Do not use `this._isFirstPlay` flag but distinguish between before pre bumper and after using `adBreakPosition` getter

BTW, Remove irrelevant code of `preload`

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [x] new unit / functional tests have been added (whenever applicable)
* [x] test are passing in local environment
* [ ] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
