### PR TITLE
feat(FEC-9142): getting bumper from provider by entry Id (OVP)

### DIFF
--- a/src/bumper.js
+++ b/src/bumper.js
@@ -97,6 +97,10 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
    * @returns {void}
    */
   updateConfig(update: Object): void {
+    if (update.id) {
+      // let kaltura player to load the bumper by entryId
+      this.config.url = '';
+    }
     super.updateConfig(update);
     this._validatePosition();
   }


### PR DESCRIPTION
### Description of the Changes

remove bumper `url` when the `is` updated to allow kaltura-player to load it from the provider - https://github.com/kaltura/kaltura-player-js/pull/261

### CheckLists

* [ ] changes have been done against master branch, and PR does not conflict
* [ ] new unit / functional tests have been added (whenever applicable)
* [ ] test are passing in local environment
* [ ] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
