### PR TITLE
fix(FEC-9425): when open dev-tool and bumper on fullscreen, bumper on top of content

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -12,6 +12,7 @@
 }
 
 .playkit-bumper-container {
+  background-color: rgb(0, 0, 0);
   visibility: hidden;
   position: absolute;
   width: 100%;


### PR DESCRIPTION
### Description of the Changes

**Issue:** A mismatch between the dimensions of the bumper source and the content source
**Solution:** Hide the content while bumper is playing (like ima-sdk does)

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [ ] new unit / functional tests have been added (whenever applicable)
* [ ] test are passing in local environment
* [ ] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
