### PR TITLE
fix(FEC-9528): the bumper is hidden when playOnMainVideoTag is true

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -12,7 +12,6 @@
 }
 
 .playkit-bumper-container {
-  background-color: rgb(0, 0, 0);
   visibility: hidden;
   position: absolute;
   width: 100%;
@@ -24,6 +23,7 @@
 }
 
 .playkit-bumper-container video {
+  background-color: rgb(0, 0, 0);
   width: 100%;
   height: 100%;
 }

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -372,6 +372,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
       }
       this._state = BumperState.PLAYING;
       this._showElement(this._bumperContainerDiv);
+      this.playOnMainVideoTag() ? this._hideElement(this._bumperVideoElement) : this._showElement(this._bumperVideoElement);
     }
   }
 

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -559,6 +559,28 @@ describe('Bumper', () => {
       });
       player.play();
     });
+
+    it('Should show the bumper video while playing', done => {
+      eventManager.listenOnce(player, player.Event.AD_STARTED, () => {
+        try {
+          setTimeout(() => {
+            player.plugins.bumper._bumperVideoElement.style.visibility.should.equal('visible');
+            done();
+          });
+        } catch (e) {
+          done(e);
+        }
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            position: [BumperType.PREROLL]
+          }
+        },
+        sources
+      });
+      player.play();
+    });
   });
 
   describe('Non sibling video tags', () => {
@@ -962,6 +984,28 @@ describe('Bumper', () => {
         plugins: {
           bumper: {
             url: 'some/invalid/url'
+          }
+        },
+        sources
+      });
+      player.play();
+    });
+
+    it('Should hide the bumper video while playing', done => {
+      eventManager.listenOnce(player, player.Event.AD_STARTED, () => {
+        try {
+          setTimeout(() => {
+            player.plugins.bumper._bumperVideoElement.style.visibility.should.equal('hidden');
+            done();
+          });
+        } catch (e) {
+          done(e);
+        }
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            position: [BumperType.PREROLL]
           }
         },
         sources


### PR DESCRIPTION
### Description of the Changes

move the black-screen (from https://github.com/kaltura/playkit-js-bumper/pull/22) to the `video`
and hide the video while `playOnMainVideoTag()` is `true`

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [x] new unit / functional tests have been added (whenever applicable)
* [x] test are passing in local environment
* [x] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
