### PR TITLE
fix: bumper covers the playback

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -12,7 +12,6 @@
 }
 
 .playkit-bumper-container {
-  visibility: hidden;
   position: absolute;
   width: 100%;
   min-height: 100%;

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -277,6 +277,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     Utils.Dom.appendChild(this._bumperContainerDiv, this._bumperVideoElement);
     // Append the bumper container to the dom
     Utils.Dom.appendChild(playerView, this._bumperContainerDiv);
+    this._hideElement(this._bumperContainerDiv);
     this._initBumperCover();
     this._initBumperClickElement();
   }
@@ -484,7 +485,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   }
 
   _showElement(el: ?HTMLElement): void {
-    el && (el.style.visibility = 'visible');
+    el && el.style.removeProperty('visibility');
   }
 
   _hideElement(el: ?HTMLElement): void {

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -564,7 +564,7 @@ describe('Bumper', () => {
       eventManager.listenOnce(player, player.Event.AD_STARTED, () => {
         try {
           setTimeout(() => {
-            player.plugins.bumper._bumperVideoElement.style.visibility.should.equal('visible');
+            player.plugins.bumper._bumperVideoElement.style.visibility.should.equal('');
             done();
           });
         } catch (e) {


### PR DESCRIPTION
### Description of the Changes

**Issue:** Since https://github.com/kaltura/playkit-js-bumper/pull/35 the video is visible after is done even his container is hidden. 
**Solution:** Show an element by removing the `visibility` property (let it get the default) 

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [ ] new unit / functional tests have been added (whenever applicable)
* [ ] test are passing in local environment
* [ ] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
