### PR TITLE
fix(FEC-9533): the player in error screen when bumper preload is failed and playOnMainVideoTag is true

### DIFF
--- a/src/bumper-engine-decorator.js
+++ b/src/bumper-engine-decorator.js
@@ -1,6 +1,7 @@
 // @flow
 import {FakeEvent, EventType} from '@playkit-js/playkit-js';
 import {Bumper, BumperBreakType} from './bumper';
+import {BumperState} from './bumper-state';
 
 /**
  * Engine decorator for bumper plugin.
@@ -17,7 +18,7 @@ class BumperEngineDecorator implements IEngineDecorator {
   }
 
   get active(): boolean {
-    return this._plugin.playOnMainVideoTag() && this._plugin.isAdPlaying();
+    return this._plugin.playOnMainVideoTag() && (this._plugin.isAdPlaying() || this._plugin.state === BumperState.LOADING);
   }
 
   dispatchEvent(event: FakeEvent): boolean {

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -774,6 +774,39 @@ describe('Bumper', () => {
       player.play();
     });
 
+    it('Should mask the bumper loading events', done => {
+      eventManager.listenOnce(player, player.Event.LOAD_START, () => {
+        done(new Error('LOAD_START should not triggered while bumper loading'));
+      });
+      setTimeout(done, 100);
+      player.configure({
+        plugins: {
+          bumper: {
+            position: [BumperBreakType.PREROLL]
+          }
+        },
+        sources
+      });
+      player.load();
+    });
+
+    it('Should mask the bumper loading error', done => {
+      eventManager.listenOnce(player, player.Event.ERROR, () => {
+        done(new Error('ERROR should not triggered while bumper loading'));
+      });
+      setTimeout(done, 100);
+      player.configure({
+        plugins: {
+          bumper: {
+            position: [BumperBreakType.PREROLL],
+            url: 'some/invalid/url'
+          }
+        },
+        sources
+      });
+      player.load();
+    });
+
     it('Should not load the content while the bumper', done => {
       eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
         try {


### PR DESCRIPTION
### Description of the Changes

Mask the loading events in the bumper engine decorator 

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [x] new unit / functional tests have been added (whenever applicable)
* [x] test are passing in local environment
* [x] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
