### PR TITLE
fix(FEC-9514): mismatch between the player size and the bumper

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -17,11 +17,8 @@
   min-height: 100%;
 }
 
-.playkit-fullscreen .playkit-bumper-container {
-  height: 100%;
-}
-
 .playkit-bumper-container video {
+  position: absolute;
   background-color: rgb(0, 0, 0);
   width: 100%;
   height: 100%;


### PR DESCRIPTION
### Description of the Changes

* set `position: absolute` to the bumper video element (like the main video element has)
* As a result, the full-screen rule not needed anymore (#8)

Solves FEC-9514

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [ ] new unit / functional tests have been added (whenever applicable)
* [ ] test are passing in local environment
* [ ] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
