### PR TITLE
fix(FEC-9594): the playback failed after the bumper finished when "disableMediaPreload: true"

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@playkit-js/playkit-js": "0.50.0-canary.add5823",
+    "@playkit-js/playkit-js": "0.59.2",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-eslint": "^7.1.1",
@@ -74,7 +74,7 @@
     "webpack-dev-server": "latest"
   },
   "peerDependencies": {
-    "@playkit-js/playkit-js": "0.50.0-canary.add5823"
+    "@playkit-js/playkit-js": "0.59.2"
   },
   "repository": {
     "type": "git",

--- a/src/bumper-middleware.js
+++ b/src/bumper-middleware.js
@@ -51,13 +51,13 @@ class BumperMiddleware extends BaseMiddleware {
    * @returns {void}
    */
   play(next: Function): void {
-    if (this._isFirstPlay && !this._context.playOnMainVideoTag()) {
-      if (this._context.config.disableMediaPreload) {
-        if (!this._context.player.getVideoElement().src) {
-          this._context.player.getVideoElement().load();
-        }
+    if (this._isFirstPlay) {
+      if (this._context.config.disableMediaPreload || this._context.playOnMainVideoTag()) {
         this._context.eventManager.listenOnce(this._context.player, EventType.AD_BREAK_END, () => this._callNextLoad());
         this._context.eventManager.listenOnce(this._context.player, EventType.AD_ERROR, () => this._callNextLoad());
+        if (!(this._context.playOnMainVideoTag() && this._context.player.getVideoElement().src)) {
+          this._context.player.getVideoElement().load();
+        }
       } else {
         this._callNextLoad();
       }
@@ -114,7 +114,7 @@ class BumperMiddleware extends BaseMiddleware {
   }
 
   _callNextLoad(): void {
-    if (this._nextLoad && !this._context.playOnMainVideoTag()) {
+    if (this._nextLoad) {
       this.callNext(this._nextLoad);
     }
     this._nextLoad = null;

--- a/src/bumper-middleware.js
+++ b/src/bumper-middleware.js
@@ -34,6 +34,7 @@ class BumperMiddleware extends BaseMiddleware {
    */
   load(next: Function): void {
     this._nextLoad = next;
+    this._context.eventManager.listenOnce(this._context.player, EventType.AD_ERROR, () => this._callNextLoad());
     if (
       this._context.adBreakPosition === BumperBreakType.PREROLL &&
       !(this._context.playOnMainVideoTag() && this._context.player.getVideoElement().src)
@@ -54,8 +55,7 @@ class BumperMiddleware extends BaseMiddleware {
     if (this._isFirstPlay) {
       if (this._context.config.disableMediaPreload || this._context.playOnMainVideoTag()) {
         this._context.eventManager.listenOnce(this._context.player, EventType.AD_BREAK_END, () => this._callNextLoad());
-        this._context.eventManager.listenOnce(this._context.player, EventType.AD_ERROR, () => this._callNextLoad());
-        if (!(this._context.playOnMainVideoTag() && this._context.player.getVideoElement().src)) {
+        if (!(this._context.playOnMainVideoTag() || this._context.player.getVideoElement().src)) {
           this._context.player.getVideoElement().load();
         }
       } else {

--- a/src/bumper-middleware.js
+++ b/src/bumper-middleware.js
@@ -56,6 +56,8 @@ class BumperMiddleware extends BaseMiddleware {
         if (!this._context.player.getVideoElement().src) {
           this._context.player.getVideoElement().load();
         }
+        this._context.eventManager.listenOnce(this._context.player, EventType.AD_BREAK_END, () => this._callNextLoad());
+        this._context.eventManager.listenOnce(this._context.player, EventType.AD_ERROR, () => this._callNextLoad());
       } else {
         this._callNextLoad();
       }
@@ -112,7 +114,7 @@ class BumperMiddleware extends BaseMiddleware {
   }
 
   _callNextLoad(): void {
-    if (this._nextLoad && !(this._context.playOnMainVideoTag() || this._context.config.disableMediaPreload)) {
+    if (this._nextLoad && !this._context.playOnMainVideoTag()) {
       this.callNext(this._nextLoad);
     }
     this._nextLoad = null;

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -32,6 +32,7 @@ function validateAdParams(event, isAdDataLoaded) {
   event.payload.ad.url.should.equal(BUMPER_URL);
   isAdDataLoaded ? Math.floor(event.payload.ad.duration).should.equal(BUMPER_DURATION) : null;
 }
+
 function validateAdBreakParams(event, isPreroll) {
   event.payload.adBreak.numAds.should.equal(1);
   isPreroll
@@ -208,7 +209,7 @@ describe('Bumper', () => {
       player.play();
     });
 
-    it('Should load the content while the bumper', done => {
+    it('Should load the content while the bumper playing', done => {
       eventManager.listenOnce(player, player.Event.LOAD_START, () => {
         eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
           done();
@@ -225,7 +226,7 @@ describe('Bumper', () => {
       player.play();
     });
 
-    it('Should not load the content while the bumper', done => {
+    it('Should load the content only once the bumper finished', done => {
       eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
         eventManager.listenOnce(player, player.Event.LOAD_START, () => {
           done();
@@ -234,6 +235,25 @@ describe('Bumper', () => {
       player.configure({
         plugins: {
           bumper: {
+            position: [BumperBreakType.PREROLL],
+            disableMediaPreload: true
+          }
+        },
+        sources
+      });
+      player.play();
+    });
+
+    it('Should load the content only once the bumper failed', done => {
+      eventManager.listenOnce(player, player.Event.AD_ERROR, () => {
+        eventManager.listenOnce(player, player.Event.LOAD_START, () => {
+          done();
+        });
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            url: 'some/invalid/url',
             position: [BumperBreakType.PREROLL],
             disableMediaPreload: true
           }
@@ -807,7 +827,7 @@ describe('Bumper', () => {
       player.load();
     });
 
-    it('Should not load the content while the bumper', done => {
+    it('Should load the content only once the bumper finished', done => {
       eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
         try {
           player.getVideoElement().src.should.equal(BUMPER_URL);
@@ -821,6 +841,24 @@ describe('Bumper', () => {
       player.configure({
         plugins: {
           bumper: {
+            position: [BumperBreakType.PREROLL]
+          }
+        },
+        sources
+      });
+      player.play();
+    });
+
+    it('Should load the content only once the bumper failed', done => {
+      eventManager.listenOnce(player, player.Event.AD_ERROR, () => {
+        eventManager.listenOnce(player, player.Event.LOAD_START, () => {
+          done();
+        });
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            url: 'some/invalid/url',
             position: [BumperBreakType.PREROLL]
           }
         },

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -244,7 +244,26 @@ describe('Bumper', () => {
       player.play();
     });
 
-    it('Should load the content only once the bumper failed', done => {
+    it('Should load the content only once the bumper load failed', done => {
+      eventManager.listenOnce(player, player.Event.AD_ERROR, () => {
+        eventManager.listenOnce(player, player.Event.LOAD_START, () => {
+          done();
+        });
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            url: 'some/invalid/url',
+            position: [BumperBreakType.PREROLL],
+            disableMediaPreload: true
+          }
+        },
+        sources
+      });
+      player.load();
+    });
+
+    it('Should load the content only once the bumper play failed', done => {
       eventManager.listenOnce(player, player.Event.AD_ERROR, () => {
         eventManager.listenOnce(player, player.Event.LOAD_START, () => {
           done();
@@ -849,7 +868,31 @@ describe('Bumper', () => {
       player.play();
     });
 
-    it('Should load the content only once the bumper failed', done => {
+    it('Should load the content only once the bumper load failed', done => {
+      eventManager.listenOnce(player, player.Event.AD_ERROR, () => {
+        eventManager.listenOnce(player, player.Event.LOAD_START, () => {
+          eventManager.listenOnce(player, player.Event.PLAYING, () => {
+            done();
+          });
+          player.play();
+        });
+      });
+      player.configure({
+        playback: {
+          preload: 'auto'
+        },
+        plugins: {
+          bumper: {
+            url: 'some/invalid/url',
+            position: [BumperBreakType.PREROLL]
+          }
+        },
+        sources
+      });
+      player.load();
+    });
+
+    it('Should load the content only once the bumper play failed', done => {
       eventManager.listenOnce(player, player.Event.AD_ERROR, () => {
         eventManager.listenOnce(player, player.Event.LOAD_START, () => {
           done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@playkit-js/playkit-js@0.50.0-canary.add5823":
-  version "0.50.0-canary.add5823"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.50.0-canary.add5823.tgz#fa6c3549aacf603a7b9238ac72a1d124aa6556ec"
+"@playkit-js/playkit-js@0.59.2":
+  version "0.59.2"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.59.2.tgz#0e08b22cd8c99dd0d39594a223c632a17b3b3748"
   dependencies:
     js-logger "^1.3.0"
     ua-parser-js "^0.7.13"


### PR DESCRIPTION
### Description of the Changes

* Since https://github.com/kaltura/playkit-js/pull/431 need to load the next also when:
   `disableMediaPreload: true` ,`playOnMainVideoTag :true`
once the bumper finished or failed 
* update playkit to `0.59.2`

Solves FEC-9594

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [x] new unit / functional tests have been added (whenever applicable)
* [x] test are passing in local environment
* [x] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
