### PR TITLE
fix(FEC-10676): no post bumper displayed

### DIFF
--- a/src/bumper.js
+++ b/src/bumper.js
@@ -209,7 +209,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
 
   loadMedia(): void {
     if (this.config.url) {
-      this.dispatchEvent(EventType.AD_MANIFEST_LOADED, {adBreaksPosition: this.config.position});
+      this.dispatchEvent(EventType.AD_MANIFEST_LOADED, {adBreaksPosition: [...this.config.position]});
     } else {
       this._state = BumperState.DONE;
       this._bumperCompletedPromise = Promise.resolve();


### PR DESCRIPTION
### Description of the Changes

Issue: Youbora keeps the `e.payload.adBreakPosition` on `AD_MANIFEST_LOADED`, and changes it on `AD_PROGRESS` for internal use. This causes the bumper's `config.position` to changed.
Solution: Passing a copy of the `config.position` on `AD_MANIFEST_LOADED` to keep it read-only

Solves FEC-10676

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
