### PR TITLE
feat(FEC-10041): playing Bumper on same video tag pause on the beginning and can't work with playWithMSE.

### DIFF
--- a/src/bumper-engine-decorator.js
+++ b/src/bumper-engine-decorator.js
@@ -3,7 +3,7 @@ import {core} from 'kaltura-player-js';
 import {Bumper, BumperBreakType} from './bumper';
 import {BumperState} from './bumper-state';
 
-const {FakeEvent, EventType} = core;
+const {FakeEvent, EventType, EngineDecoratorPriority} = core;
 
 /**
  * Engine decorator for bumper plugin.
@@ -21,6 +21,10 @@ class BumperEngineDecorator implements IEngineDecorator {
 
   get active(): boolean {
     return this._plugin.playOnMainVideoTag() && (this._plugin.isAdPlaying() || this._plugin.state === BumperState.LOADING);
+  }
+
+  get priority(): number {
+    return EngineDecoratorPriority.PREFERRED;
   }
 
   dispatchEvent(event: FakeEvent): boolean {

--- a/src/bumper-engine-decorator.js
+++ b/src/bumper-engine-decorator.js
@@ -3,7 +3,7 @@ import {core} from 'kaltura-player-js';
 import {Bumper, BumperBreakType} from './bumper';
 import {BumperState} from './bumper-state';
 
-const {FakeEvent, EventType, EngineDecoratorPriority} = core;
+const {FakeEvent, EventType} = core;
 
 /**
  * Engine decorator for bumper plugin.
@@ -21,10 +21,6 @@ class BumperEngineDecorator implements IEngineDecorator {
 
   get active(): boolean {
     return this._plugin.playOnMainVideoTag() && (this._plugin.isAdPlaying() || this._plugin.state === BumperState.LOADING);
-  }
-
-  get priority(): number {
-    return EngineDecoratorPriority.PREFERRED;
   }
 
   dispatchEvent(event: FakeEvent): boolean {

--- a/src/bumper-middleware.js
+++ b/src/bumper-middleware.js
@@ -36,10 +36,7 @@ class BumperMiddleware extends BaseMiddleware {
   load(next: Function): void {
     this._nextLoad = next;
     this._context.eventManager.listenOnce(this._context.player, EventType.AD_ERROR, () => this._callNextLoad());
-    if (
-      this._context.adBreakPosition === BumperBreakType.PREROLL &&
-      !(this._context.playOnMainVideoTag() && this._context.player.getVideoElement().src)
-    ) {
+    if (this._context.adBreakPosition === BumperBreakType.PREROLL && !this._context.playOnMainVideoTag()) {
       this._context.load();
     }
     if (!(this._context.config.url && this._context.config.position.includes(BumperBreakType.PREROLL))) {

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -142,6 +142,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   play(): void {
     this.load();
     this._adBreak = true;
+    this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
     this._hideElement(this._bumperCoverDiv);
     const playPromise = this._videoElement.play();
     if (playPromise) {
@@ -360,7 +361,6 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   _onPlaying(): void {
     if (this._adBreak) {
       if (this._bumperState === BumperState.LOADED) {
-        this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
         this.dispatchEvent(EventType.AD_STARTED, {ad: this._getAd()});
       }
       if (this._bumperState === BumperState.PAUSED) {


### PR DESCRIPTION
### Description of the Changes

Issue: Bumper fires ad break start too late.
Bumper set the stream on load before it fired the ad_break_end and it breaks the behavior we have for playWithMSE which removing the playback on ad break start.
Solution: don't load until ad break start and set ad break starts on the play when we set adBreak=true to make it coordinated.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
