### PR TITLE
fix(FEC-11005): Bumper doesn't work with playAdsWithMSE config

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,9 +1,3 @@
-let webpackConfig = require('./webpack.config.js');
-//Need to remove externals otherwise they won't be included in test
-delete webpackConfig.externals;
-// Need to define inline source maps when using karma
-webpackConfig.devtool = 'inline-source-map';
-
 const isWindows = /^win/.test(process.platform);
 const isMacOS = /^darwin/.test(process.platform);
 // Create custom launcher in case running with Travis
@@ -14,12 +8,20 @@ const customLaunchers = {
   }
 };
 
+const launchers = {
+  Chrome_browser: {
+    base: 'Chrome',
+    flags: ['--no-sandbox', '--autoplay-policy=no-user-gesture-required']
+  }
+};
+
 module.exports = function (config) {
   let karmaConf = {
     logLevel: config.LOG_INFO,
     browserDisconnectTimeout: 30000,
     browserNoActivityTimeout: 60000,
-    browsers: ['Chrome', 'Firefox'],
+    customLaunchers: launchers,
+    browsers: ['Chrome_browser', 'Firefox'],
     concurrency: 1,
     singleRun: true,
     colors: true,
@@ -30,7 +32,12 @@ module.exports = function (config) {
       'test/setup/karma.js': ['webpack', 'sourcemap']
     },
     reporters: ['mocha', 'coverage'],
-    webpack: webpackConfig,
+    webpack: {
+      ...require('./webpack.config.js'),
+      externals: {}, //Need to remove externals otherwise they won't be included in test
+      devtool: 'inline-source-map', // Need to define inline source maps when using karma
+      mode: config.mode || 'development' // run in development mode by default to avoid minifying -> faster
+    },
     webpackServer: {
       noInfo: true
     },

--- a/src/bumper-middleware.js
+++ b/src/bumper-middleware.js
@@ -37,9 +37,10 @@ class BumperMiddleware extends BaseMiddleware {
     this._nextLoad = next;
     this._context.eventManager.listenOnce(this._context.player, EventType.AD_ERROR, () => this._callNextLoad());
     if (
-      (this._context.adBreakPosition === BumperBreakType.PREROLL && !this._context.playOnMainVideoTag()) ||
-      //preload
-      (this._context.adBreakPosition === BumperBreakType.PREROLL && !this._context.player.getVideoElement().src)
+      this._context.adBreakPosition === BumperBreakType.PREROLL &&
+      (!this._context.playOnMainVideoTag() ||
+        //preload
+        !this._context.player.getVideoElement().src)
     ) {
       this._context.load();
     }

--- a/src/bumper-middleware.js
+++ b/src/bumper-middleware.js
@@ -37,8 +37,9 @@ class BumperMiddleware extends BaseMiddleware {
     this._nextLoad = next;
     this._context.eventManager.listenOnce(this._context.player, EventType.AD_ERROR, () => this._callNextLoad());
     if (
-      this._context.adBreakPosition === BumperBreakType.PREROLL &&
-      !(this._context.playOnMainVideoTag() && this._context.player.getVideoElement().src)
+      (this._context.adBreakPosition === BumperBreakType.PREROLL && !this._context.playOnMainVideoTag()) ||
+      //preload
+      (this._context.adBreakPosition === BumperBreakType.PREROLL && !this._context.player.getVideoElement().src)
     ) {
       this._context.load();
     }

--- a/src/bumper-middleware.js
+++ b/src/bumper-middleware.js
@@ -36,10 +36,7 @@ class BumperMiddleware extends BaseMiddleware {
   load(next: Function): void {
     this._nextLoad = next;
     this._context.eventManager.listenOnce(this._context.player, EventType.AD_ERROR, () => this._callNextLoad());
-    if (
-      this._context.adBreakPosition === BumperBreakType.PREROLL &&
-      !(this._context.playOnMainVideoTag() && this._context.player.getVideoElement().src)
-    ) {
+    if (this._context.adBreakPosition === BumperBreakType.PREROLL && !this._context.playOnMainVideoTag()) {
       this._context.load();
     }
     if (!(this._context.config.url && this._context.config.position.includes(BumperBreakType.PREROLL))) {

--- a/src/bumper-middleware.js
+++ b/src/bumper-middleware.js
@@ -36,7 +36,10 @@ class BumperMiddleware extends BaseMiddleware {
   load(next: Function): void {
     this._nextLoad = next;
     this._context.eventManager.listenOnce(this._context.player, EventType.AD_ERROR, () => this._callNextLoad());
-    if (this._context.adBreakPosition === BumperBreakType.PREROLL && !this._context.playOnMainVideoTag()) {
+    if (
+      this._context.adBreakPosition === BumperBreakType.PREROLL &&
+      !(this._context.playOnMainVideoTag() && this._context.player.getVideoElement().src)
+    ) {
       this._context.load();
     }
     if (!(this._context.config.url && this._context.config.position.includes(BumperBreakType.PREROLL))) {

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -141,6 +141,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
    */
   play(): void {
     this._adBreak = true;
+    this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
     this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
     this.load();
     this._hideElement(this._bumperCoverDiv);
@@ -490,7 +491,10 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
 
   load(): void {
     if (this._bumperState === BumperState.IDLE) {
-      this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
+      //preload
+      if (!this._adBreak) {
+        this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
+      }
       this._state = BumperState.LOADING;
       this.eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => this._onLoadedData());
       if (this.playOnMainVideoTag()) {

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -142,6 +142,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   play(): void {
     this.load();
     this._adBreak = true;
+    this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
     this._hideElement(this._bumperCoverDiv);
     const playPromise = this._videoElement.play();
     if (playPromise) {
@@ -360,7 +361,6 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   _onPlaying(): void {
     if (this._adBreak) {
       if (this._bumperState === BumperState.LOADED) {
-        this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
         this.dispatchEvent(EventType.AD_STARTED, {ad: this._getAd()});
       }
       if (this._bumperState === BumperState.PAUSED) {

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -141,10 +141,12 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
    */
   play(): void {
     if (!this._adBreak) {
-      this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
+      if (this._bumperState === BumperState.IDLE) {
+        this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
+      }
+      this._adBreak = true;
+      this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
     }
-    this._adBreak = true;
-    this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
     this.load();
     this._hideElement(this._bumperCoverDiv);
     const playPromise = this._videoElement.play();

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -140,9 +140,9 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
    * @memberof Bumper
    */
   play(): void {
-    this.load();
     this._adBreak = true;
     this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
+    this.load();
     this._hideElement(this._bumperCoverDiv);
     const playPromise = this._videoElement.play();
     if (playPromise) {

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -140,13 +140,11 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
    * @memberof Bumper
    */
   play(): void {
-    if (!this._adBreak) {
-      if (this._bumperState === BumperState.IDLE) {
-        this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
-      }
-      this._adBreak = true;
+    //preload
+    if ([BumperState.LOADING, BumperState.LOADED].includes(this._bumperState)) {
       this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
     }
+    this._adBreak = true;
     this.load();
     this._hideElement(this._bumperCoverDiv);
     const playPromise = this._videoElement.play();
@@ -495,10 +493,12 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
 
   load(): void {
     if (this._bumperState === BumperState.IDLE) {
-      if (!this._adBreak) {
-        this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
-      }
+      this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
       this._state = BumperState.LOADING;
+      //not preload - load called from play
+      if (this._adBreak) {
+        this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
+      }
       this.eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => this._onLoadedData());
       if (this.playOnMainVideoTag()) {
         this.logger.debug('Switch source to bumper url');

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -140,11 +140,11 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
    * @memberof Bumper
    */
   play(): void {
-    if (this._bumperState === BumperState.IDLE) {
-      this._adBreak = true;
+    if (!this._adBreak) {
       this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
-      this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
     }
+    this._adBreak = true;
+    this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
     this.load();
     this._hideElement(this._bumperCoverDiv);
     const playPromise = this._videoElement.play();
@@ -493,7 +493,6 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
 
   load(): void {
     if (this._bumperState === BumperState.IDLE) {
-      //preload
       if (!this._adBreak) {
         this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
       }

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -140,9 +140,11 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
    * @memberof Bumper
    */
   play(): void {
-    this._adBreak = true;
-    this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
-    this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
+    if (this._bumperState === BumperState.IDLE) {
+      this._adBreak = true;
+      this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
+      this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
+    }
     this.load();
     this._hideElement(this._bumperCoverDiv);
     const playPromise = this._videoElement.play();

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -102,39 +102,37 @@ describe('Bumper', () => {
                     eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
                       eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
                         eventManager.listenOnce(player, player.Event.PLAYING, () => {
-                          eventManager.listenOnce(player, player.Event.ENDED, () => {
-                            eventManager.listenOnce(player, player.Event.AD_BREAK_START, event => {
+                          eventManager.listenOnce(player, player.Event.AD_BREAK_START, event => {
+                            try {
+                              validateAdBreakParams(event, false);
+                            } catch (e) {
+                              done(e);
+                            }
+                            eventManager.listenOnce(player, player.Event.AD_STARTED, event => {
                               try {
-                                validateAdBreakParams(event, false);
+                                validateAdParams(event, true);
                               } catch (e) {
                                 done(e);
                               }
-                              eventManager.listenOnce(player, player.Event.AD_STARTED, event => {
+                              eventManager.listenOnce(player, player.Event.AD_PROGRESS, event => {
                                 try {
-                                  validateAdParams(event, true);
+                                  validateAdProgressParams(event);
                                 } catch (e) {
                                   done(e);
                                 }
-                                eventManager.listenOnce(player, player.Event.AD_PROGRESS, event => {
-                                  try {
-                                    validateAdProgressParams(event);
-                                  } catch (e) {
-                                    done(e);
-                                  }
-                                  eventManager.listenOnce(player, player.Event.AD_PAUSED, () => {
-                                    eventManager.listenOnce(player, player.Event.AD_RESUMED, () => {
-                                      eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
-                                        eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
-                                          eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
-                                            done();
-                                          });
+                                eventManager.listenOnce(player, player.Event.AD_PAUSED, () => {
+                                  eventManager.listenOnce(player, player.Event.AD_RESUMED, () => {
+                                    eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
+                                      eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
+                                        eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+                                          done();
                                         });
                                       });
                                     });
-                                    player.play();
                                   });
-                                  player.pause();
+                                  player.play();
                                 });
+                                player.pause();
                               });
                             });
                           });
@@ -694,41 +692,39 @@ describe('Bumper', () => {
                     eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
                       eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
                         eventManager.listenOnce(player, player.Event.PLAYING, () => {
-                          eventManager.listenOnce(player, player.Event.ENDED, () => {
-                            eventManager.listenOnce(player, player.Event.AD_BREAK_START, event => {
+                          eventManager.listenOnce(player, player.Event.AD_BREAK_START, event => {
+                            try {
+                              validateAdBreakParams(event, false);
+                            } catch (e) {
+                              done(e);
+                            }
+                            eventManager.listenOnce(player, player.Event.AD_STARTED, event => {
                               try {
-                                validateAdBreakParams(event, false);
+                                validateAdParams(event, true);
                               } catch (e) {
                                 done(e);
                               }
-                              eventManager.listenOnce(player, player.Event.AD_STARTED, event => {
+                              eventManager.listenOnce(player, player.Event.AD_PROGRESS, event => {
                                 try {
-                                  validateAdParams(event, true);
+                                  validateAdProgressParams(event);
                                 } catch (e) {
                                   done(e);
                                 }
-                                eventManager.listenOnce(player, player.Event.AD_PROGRESS, event => {
-                                  try {
-                                    validateAdProgressParams(event);
-                                  } catch (e) {
-                                    done(e);
-                                  }
-                                  eventManager.listenOnce(player, player.Event.AD_PAUSED, () => {
-                                    eventManager.listenOnce(player, player.Event.AD_RESUMED, () => {
-                                      eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
-                                        eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
-                                          eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
-                                            eventManager.listenOnce(player, player.Event.PLAYBACK_ENDED, () => {
-                                              done();
-                                            });
+                                eventManager.listenOnce(player, player.Event.AD_PAUSED, () => {
+                                  eventManager.listenOnce(player, player.Event.AD_RESUMED, () => {
+                                    eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
+                                      eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
+                                        eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+                                          eventManager.listenOnce(player, player.Event.PLAYBACK_ENDED, () => {
+                                            done();
                                           });
                                         });
                                       });
                                     });
-                                    player.play();
                                   });
-                                  player.pause();
+                                  player.play();
                                 });
+                                player.pause();
                               });
                             });
                           });

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -399,18 +399,20 @@ describe('Bumper', () => {
       eventManager.listen(player, player.Event.AD_LOADED, () => {
         counter++;
       });
-      eventManager.listenOnce(player, player.Event.PLAYING, () => {
-        eventManager.listenOnce(player, player.Event.ENDED, () => {
-          eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
-            try {
-              counter.should.equal(1);
-              done();
-            } catch (e) {
-              done(e);
-            }
+      eventManager.listenOnce(player, player.Event.AD_BREAK_START, () => {
+        eventManager.listenOnce(player, player.Event.PLAYING, () => {
+          eventManager.listenOnce(player, player.Event.ENDED, () => {
+            eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+              try {
+                counter.should.equal(1);
+                done();
+              } catch (e) {
+                done(e);
+              }
+            });
           });
+          player.currentTime = player.duration;
         });
-        player.currentTime = player.duration;
       });
       player.configure({sources});
       setTimeout(() => player.play(), 1000);
@@ -421,18 +423,20 @@ describe('Bumper', () => {
       eventManager.listen(player, player.Event.AD_LOADED, () => {
         counter++;
       });
-      eventManager.listenOnce(player, player.Event.PLAYING, () => {
-        eventManager.listenOnce(player, player.Event.ENDED, () => {
-          eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
-            try {
-              counter.should.equal(1);
-              done();
-            } catch (e) {
-              done(e);
-            }
+      eventManager.listenOnce(player, player.Event.AD_BREAK_START, () => {
+        eventManager.listenOnce(player, player.Event.PLAYING, () => {
+          eventManager.listenOnce(player, player.Event.ENDED, () => {
+            eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+              try {
+                counter.should.equal(1);
+                done();
+              } catch (e) {
+                done(e);
+              }
+            });
           });
+          player.currentTime = player.duration;
         });
-        player.currentTime = player.duration;
       });
       player.configure({
         playback: {
@@ -692,39 +696,41 @@ describe('Bumper', () => {
                     eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
                       eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
                         eventManager.listenOnce(player, player.Event.PLAYING, () => {
-                          eventManager.listenOnce(player, player.Event.AD_BREAK_START, event => {
-                            try {
-                              validateAdBreakParams(event, false);
-                            } catch (e) {
-                              done(e);
-                            }
-                            eventManager.listenOnce(player, player.Event.AD_STARTED, event => {
+                          eventManager.listenOnce(player, player.Event.AD_LOADED, () => {
+                            eventManager.listenOnce(player, player.Event.AD_BREAK_START, event => {
                               try {
-                                validateAdParams(event, true);
+                                validateAdBreakParams(event, false);
                               } catch (e) {
                                 done(e);
                               }
-                              eventManager.listenOnce(player, player.Event.AD_PROGRESS, event => {
+                              eventManager.listenOnce(player, player.Event.AD_STARTED, event => {
                                 try {
-                                  validateAdProgressParams(event);
+                                  validateAdParams(event, true);
                                 } catch (e) {
                                   done(e);
                                 }
-                                eventManager.listenOnce(player, player.Event.AD_PAUSED, () => {
-                                  eventManager.listenOnce(player, player.Event.AD_RESUMED, () => {
-                                    eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
-                                      eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
-                                        eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
-                                          eventManager.listenOnce(player, player.Event.PLAYBACK_ENDED, () => {
-                                            done();
+                                eventManager.listenOnce(player, player.Event.AD_PROGRESS, event => {
+                                  try {
+                                    validateAdProgressParams(event);
+                                  } catch (e) {
+                                    done(e);
+                                  }
+                                  eventManager.listenOnce(player, player.Event.AD_PAUSED, () => {
+                                    eventManager.listenOnce(player, player.Event.AD_RESUMED, () => {
+                                      eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
+                                        eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
+                                          eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+                                            eventManager.listenOnce(player, player.Event.PLAYBACK_ENDED, () => {
+                                              done();
+                                            });
                                           });
                                         });
                                       });
                                     });
+                                    player.play();
                                   });
-                                  player.play();
+                                  player.pause();
                                 });
-                                player.pause();
                               });
                             });
                           });
@@ -997,18 +1003,20 @@ describe('Bumper', () => {
       eventManager.listen(player, player.Event.AD_LOADED, () => {
         counter++;
       });
-      eventManager.listenOnce(player, player.Event.PLAYING, () => {
-        eventManager.listenOnce(player, player.Event.ENDED, () => {
-          eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
-            try {
-              counter.should.equal(2);
-              done();
-            } catch (e) {
-              done(e);
-            }
+      eventManager.listenOnce(player, player.Event.AD_BREAK_START, () => {
+        eventManager.listenOnce(player, player.Event.PLAYING, () => {
+          eventManager.listenOnce(player, player.Event.ENDED, () => {
+            eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+              try {
+                counter.should.equal(2);
+                done();
+              } catch (e) {
+                done(e);
+              }
+            });
           });
+          player.currentTime = player.duration;
         });
-        player.currentTime = player.duration;
       });
       player.configure({sources});
       setTimeout(() => player.play(), 1000);
@@ -1019,18 +1027,20 @@ describe('Bumper', () => {
       eventManager.listen(player, player.Event.AD_LOADED, () => {
         counter++;
       });
-      eventManager.listenOnce(player, player.Event.PLAYING, () => {
-        eventManager.listenOnce(player, player.Event.ENDED, () => {
-          eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
-            try {
-              counter.should.equal(2);
-              done();
-            } catch (e) {
-              done(e);
-            }
+      eventManager.listenOnce(player, player.Event.AD_BREAK_START, () => {
+        eventManager.listenOnce(player, player.Event.PLAYING, () => {
+          eventManager.listenOnce(player, player.Event.ENDED, () => {
+            eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+              try {
+                counter.should.equal(2);
+                done();
+              } catch (e) {
+                done(e);
+              }
+            });
           });
+          player.currentTime = player.duration;
         });
-        player.currentTime = player.duration;
       });
       player.configure({
         playback: {


### PR DESCRIPTION
### Description of the Changes

Issue: Bumper doesn't work with playAdsWithMSE.
Solution: ad_break_start should dispatch once the ad starts before load and changing the source.
It split the ad_loaded into two use cases:
1. preload should dispatch from load method.
2. load -> play then we want to dispatch ad_loaded -> ad_break_start

Solves FEC-11005

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
