### PR TITLE
fix(FEC-11199): NaN shown instead of duration for bumper videos

### DIFF
--- a/src/bumper.js
+++ b/src/bumper.js
@@ -387,13 +387,14 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   }
 
   _onTimeUpdate(): void {
-    this._adBreak &&
+    if (this._adBreak && this._bumperState !== BumperState.LOADING) {
       this.dispatchEvent(EventType.AD_PROGRESS, {
         adProgress: {
           currentTime: this._videoElement.currentTime,
           duration: this._videoElement.duration
         }
       });
+    }
   }
 
   _onError(): void {


### PR DESCRIPTION
### Description of the Changes

Ignore the TIME_UPDATE before the bumper actually loaded 

Solves FEC-11199

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
