### PR TITLE
fix(FEC-10692): Youbora is missing some ad properties of post bumper

### DIFF
--- a/src/bumper.js
+++ b/src/bumper.js
@@ -239,6 +239,9 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
       this.playOnMainVideoTag() && (this._state = BumperState.IDLE);
       this.initBumperCompletedPromise();
       this.play();
+      if (this._bumperState === BumperState.LOADED && this.config.position.length === 2) {
+        this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
+      }
     }
   }
 
@@ -437,6 +440,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   _onPlayerTimeUpdate(): void {
     if (this.player.currentTime >= this.player.duration - TIME_FOR_PRELOAD && !this.playOnMainVideoTag()) {
       this.load();
+      this.eventManager.unlisten(this.player, EventType.TIME_UPDATE);
     }
   }
 
@@ -517,8 +521,6 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
         this._bumperVideoElement.src = this.config.url;
         this._bumperVideoElement.setAttribute('playsinline', '');
       }
-    } else if (this._bumperState === BumperState.LOADED) {
-      this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
     }
   }
 

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -238,10 +238,14 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     if (this._bumperState !== BumperState.DONE) {
       this.playOnMainVideoTag() && (this._state = BumperState.IDLE);
       this.initBumperCompletedPromise();
+      this._mimicAdLoadedEvent();
       this.play();
-      if (this._bumperState === BumperState.LOADED && this.config.position.length === 2) {
-        this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
-      }
+    }
+  }
+
+  _mimicAdLoadedEvent() {
+    if (this._bumperState === BumperState.LOADED) {
+      this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
     }
   }
 

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -364,6 +364,9 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   _onPlaying(): void {
     if (this._adBreak) {
       if (this._bumperState === BumperState.LOADED) {
+        if (this._getAdBreak().type === AdBreakType.POST) {
+          this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
+        }
         this.dispatchEvent(EventType.AD_STARTED, {ad: this._getAd()});
       }
       if (this._bumperState === BumperState.PAUSED) {
@@ -538,7 +541,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     return new Ad(this.config.id, adOptions);
   }
 
-  _getAdBreak(): Ad {
+  _getAdBreak(): AdBreak {
     const type = this._adBreakPosition === BumperBreakType.PREROLL ? AdBreakType.PRE : AdBreakType.POST;
     return new AdBreak({type, position: this._adBreakPosition, numAds: 1});
   }

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -350,11 +350,13 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     this.eventManager.listen(this.player, EventType.SOURCE_SELECTED, () => this._onPlayerSourceSelected());
     this.eventManager.listen(this.player, EventType.PLAYBACK_START, () => this._onPlayerPlaybackStart());
     this.eventManager.listen(this.player, EventType.PLAYBACK_ENDED, () => this._onPlayerPlaybackEnded());
-    this.eventManager.listenOnce(this.player, EventType.TIME_UPDATE, () => this._onPlayerTimeUpdate());
     this.eventManager.listen(this.player, EventType.VOLUME_CHANGE, () => this._onPlayerVolumeChange());
     this.eventManager.listen(this.player, EventType.MUTE_CHANGE, event => this._onPlayerMuteChange(event));
     this.eventManager.listen(this.player, EventType.ENTER_FULLSCREEN, () => (this._isPlayerFullscreen = true));
     this.eventManager.listen(this.player, EventType.EXIT_FULLSCREEN, () => this._onPlayerExitFullscreen());
+    if (this.config.position[0] === BumperBreakType.POSTROLL) {
+      this.eventManager.listen(this.player, EventType.TIME_UPDATE, () => this._onPlayerTimeUpdate());
+    }
   }
 
   _onLoadedData(): void {

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -221,7 +221,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
 
   onEnded(): void {
     if (this._adBreak) {
-      this._state = BumperState.LOADED;
+      this._state = BumperState.IDLE;
       this._adBreak = false;
       this._hideElement(this._bumperContainerDiv);
       this.dispatchEvent(EventType.AD_COMPLETED);
@@ -364,9 +364,6 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   _onPlaying(): void {
     if (this._adBreak) {
       if (this._bumperState === BumperState.LOADED) {
-        if (this._getAdBreak().type === AdBreakType.POST) {
-          this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
-        }
         this.dispatchEvent(EventType.AD_STARTED, {ad: this._getAd()});
       }
       if (this._bumperState === BumperState.PAUSED) {

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -354,7 +354,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     this.eventManager.listen(this.player, EventType.MUTE_CHANGE, event => this._onPlayerMuteChange(event));
     this.eventManager.listen(this.player, EventType.ENTER_FULLSCREEN, () => (this._isPlayerFullscreen = true));
     this.eventManager.listen(this.player, EventType.EXIT_FULLSCREEN, () => this._onPlayerExitFullscreen());
-    if (this.config.position[0] === BumperBreakType.POSTROLL) {
+    if (this.config.position.length === 1 && this.config.position[0] === BumperBreakType.POSTROLL) {
       this.eventManager.listen(this.player, EventType.TIME_UPDATE, () => this._onPlayerTimeUpdate());
     }
   }

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -221,7 +221,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
 
   onEnded(): void {
     if (this._adBreak) {
-      this._state = BumperState.IDLE;
+      this._state = BumperState.LOADED;
       this._adBreak = false;
       this._hideElement(this._bumperContainerDiv);
       this.dispatchEvent(EventType.AD_COMPLETED);
@@ -350,7 +350,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     this.eventManager.listen(this.player, EventType.SOURCE_SELECTED, () => this._onPlayerSourceSelected());
     this.eventManager.listen(this.player, EventType.PLAYBACK_START, () => this._onPlayerPlaybackStart());
     this.eventManager.listen(this.player, EventType.PLAYBACK_ENDED, () => this._onPlayerPlaybackEnded());
-    this.eventManager.listen(this.player, EventType.TIME_UPDATE, () => this._onPlayerTimeUpdate());
+    this.eventManager.listenOnce(this.player, EventType.TIME_UPDATE, () => this._onPlayerTimeUpdate());
     this.eventManager.listen(this.player, EventType.VOLUME_CHANGE, () => this._onPlayerVolumeChange());
     this.eventManager.listen(this.player, EventType.MUTE_CHANGE, event => this._onPlayerMuteChange(event));
     this.eventManager.listen(this.player, EventType.ENTER_FULLSCREEN, () => (this._isPlayerFullscreen = true));
@@ -515,6 +515,8 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
         this._bumperVideoElement.src = this.config.url;
         this._bumperVideoElement.setAttribute('playsinline', '');
       }
+    } else if (this._bumperState === BumperState.LOADED) {
+      this.dispatchEvent(EventType.AD_LOADED, {ad: this._getAd()});
     }
   }
 

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -394,12 +394,37 @@ describe('Bumper', () => {
       player.play();
     });
 
+    it('Should fire AD_LOADED once - preload true and and post-roll position', done => {
+      let counter = 0;
+      eventManager.listen(player, player.Event.AD_LOADED, () => {
+        counter++;
+      });
+            eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+              try {
+                counter.should.equal(1);
+                done();
+              } catch (e) {
+                done(e);
+              }
+            });
+          player.currentTime = player.duration;
+      player.configure({
+        plugins: {
+          bumper: {
+            preload: 'auto',
+            position: [BumperBreakType.PREROLL]
+          }
+        },
+        sources
+      });
+      player.play();
+    });
+
     it('Should fire AD_LOADED once - preload false and pre-roll position', done => {
       let counter = 0;
       eventManager.listen(player, player.Event.AD_LOADED, () => {
         counter++;
       });
-      eventManager.listenOnce(player, player.Event.AD_BREAK_START, () => {
         eventManager.listenOnce(player, player.Event.PLAYING, () => {
           eventManager.listenOnce(player, player.Event.ENDED, () => {
             eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
@@ -413,48 +438,15 @@ describe('Bumper', () => {
           });
           player.currentTime = player.duration;
         });
-      });
       player.configure({
         plugins: {
           bumper: {
-            position: [BumperBreakType.PREROLL]
-          }
-        },
-        sources
-      });
-      setTimeout(() => player.play(), 1000);
-    });
-
-    it('Should fire AD_LOADED once - preload true and and post-roll position', done => {
-      let counter = 0;
-      eventManager.listen(player, player.Event.AD_LOADED, () => {
-        counter++;
-      });
-      eventManager.listenOnce(player, player.Event.AD_BREAK_START, () => {
-        eventManager.listenOnce(player, player.Event.PLAYING, () => {
-          eventManager.listenOnce(player, player.Event. ENDED, () => {
-            eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
-              try {
-                counter.should.equal(1);
-                done();
-              } catch (e) {
-                done(e);
-              }
-            });
-          });
-          player.currentTime = player.duration;
-        });
-      });
-      player.configure({
-        plugins: {
-          bumper: {
-            preload: 'auto',
             position: [BumperBreakType.POSTROLL]
           }
         },
         sources
       });
-      setTimeout(() => player.play(), 1000);
+      player.play();
     });
 
     it('Should fire AD_LOADED twice - both - pre-roll & post-roll position', done => {
@@ -464,7 +456,7 @@ describe('Bumper', () => {
       });
       eventManager.listenOnce(player, player.Event.AD_BREAK_START, () => {
         eventManager.listenOnce(player, player.Event.PLAYING, () => {
-          eventManager.listenOnce(player, player.Event. ENDED, () => {
+          eventManager.listenOnce(player, player.Event.ENDED, () => {
             eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
               try {
                 counter.should.equal(2);

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -394,31 +394,7 @@ describe('Bumper', () => {
       player.play();
     });
 
-    it('Should fire AD_LOADED once - preload false', done => {
-      let counter = 0;
-      eventManager.listen(player, player.Event.AD_LOADED, () => {
-        counter++;
-      });
-      eventManager.listenOnce(player, player.Event.AD_BREAK_START, () => {
-        eventManager.listenOnce(player, player.Event.PLAYING, () => {
-          eventManager.listenOnce(player, player.Event.ENDED, () => {
-            eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
-              try {
-                counter.should.equal(1);
-                done();
-              } catch (e) {
-                done(e);
-              }
-            });
-          });
-          player.currentTime = player.duration;
-        });
-      });
-      player.configure({sources});
-      setTimeout(() => player.play(), 1000);
-    });
-
-    it('Should fire AD_LOADED once - preload true', done => {
+    it('Should fire AD_LOADED once - preload false and pre-roll position', done => {
       let counter = 0;
       eventManager.listen(player, player.Event.AD_LOADED, () => {
         counter++;
@@ -439,11 +415,69 @@ describe('Bumper', () => {
         });
       });
       player.configure({
-        playback: {
-          preload: 'auto'
+        plugins: {
+          bumper: {
+            position: [BumperBreakType.PREROLL]
+          }
         },
         sources
       });
+      setTimeout(() => player.play(), 1000);
+    });
+
+    it('Should fire AD_LOADED once - preload true and and post-roll position', done => {
+      let counter = 0;
+      eventManager.listen(player, player.Event.AD_LOADED, () => {
+        counter++;
+      });
+      eventManager.listenOnce(player, player.Event.AD_BREAK_START, () => {
+        eventManager.listenOnce(player, player.Event.PLAYING, () => {
+          eventManager.listenOnce(player, player.Event. ENDED, () => {
+            eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+              try {
+                counter.should.equal(1);
+                done();
+              } catch (e) {
+                done(e);
+              }
+            });
+          });
+          player.currentTime = player.duration;
+        });
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            preload: 'auto',
+            position: [BumperBreakType.POSTROLL]
+          }
+        },
+        sources
+      });
+      setTimeout(() => player.play(), 1000);
+    });
+
+    it('Should fire AD_LOADED twice - both - pre-roll & post-roll position', done => {
+      let counter = 0;
+      eventManager.listen(player, player.Event.AD_LOADED, () => {
+        counter++;
+      });
+      eventManager.listenOnce(player, player.Event.AD_BREAK_START, () => {
+        eventManager.listenOnce(player, player.Event.PLAYING, () => {
+          eventManager.listenOnce(player, player.Event. ENDED, () => {
+            eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+              try {
+                counter.should.equal(2);
+                done();
+              } catch (e) {
+                done(e);
+              }
+            });
+          });
+          player.currentTime = player.duration;
+        });
+      });
+      player.configure({sources});
       setTimeout(() => player.play(), 1000);
     });
 

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -399,15 +399,15 @@ describe('Bumper', () => {
       eventManager.listen(player, player.Event.AD_LOADED, () => {
         counter++;
       });
-            eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
-              try {
-                counter.should.equal(1);
-                done();
-              } catch (e) {
-                done(e);
-              }
-            });
-          player.currentTime = player.duration;
+      eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+        try {
+          counter.should.equal(1);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+      player.currentTime = player.duration;
       player.configure({
         plugins: {
           bumper: {
@@ -425,19 +425,19 @@ describe('Bumper', () => {
       eventManager.listen(player, player.Event.AD_LOADED, () => {
         counter++;
       });
-        eventManager.listenOnce(player, player.Event.PLAYING, () => {
-          eventManager.listenOnce(player, player.Event.ENDED, () => {
-            eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
-              try {
-                counter.should.equal(1);
-                done();
-              } catch (e) {
-                done(e);
-              }
-            });
+      eventManager.listenOnce(player, player.Event.PLAYING, () => {
+        eventManager.listenOnce(player, player.Event.ENDED, () => {
+          eventManager.listenOnce(player, player.Event.ALL_ADS_COMPLETED, () => {
+            try {
+              counter.should.equal(1);
+              done();
+            } catch (e) {
+              done(e);
+            }
           });
-          player.currentTime = player.duration;
         });
+        player.currentTime = player.duration;
+      });
       player.configure({
         plugins: {
           bumper: {


### PR DESCRIPTION
### Description of the Changes

**issue:** Youbora is missing some ad properties of post bumper (in adObj)

**fix:** the trigger for youbora request is the adstarted event, 
          and initialisation of the adObj is just on adloaded event, 
(and the reset of the adObj is on adcompleted event),   so the fix is to dispatch adloaded each time 
of dispatching adstartd **in case the current starting bumper is post-bumper**

solves: (FEC-10692)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
