### PR TITLE
fix(FEC-13932): Application events analytics reporting to kava | "Bumper_click" event missing bumper url - buttonValue is empty.

### DIFF
--- a/src/bumper.js
+++ b/src/bumper.js
@@ -297,7 +297,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     this._bumperClickThroughDiv.target = '_blank';
     this._bumperClickThroughDiv.onclick = () => {
       this.config.clickThroughUrl && this.dispatchEvent(EventType.AD_CLICKED);
-      this.dispatchEvent(BumperEvents.BUMPER_CLICKED);
+      this.dispatchEvent(BumperEvents.BUMPER_CLICKED, {clickThroughUrl: this.config.clickThroughUrl});
       this.pause();
       this._showElement(this._bumperCoverDiv);
     };


### PR DESCRIPTION

#### Resolves FEC-13932


#### Related PR:

https://github.com/kaltura/playkit-js-kava/pull/170