### PR TITLE
fix(FEC-14915): Add Per entry bumper video to Studio | Metadata basedbumper video doesn't work at all.

### DIFF
--- a/src/bumper.js
+++ b/src/bumper.js
@@ -49,7 +49,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     position: DEFAULT_POSITION,
     disableMediaPreload: false,
     playOnMainVideoTag: false,
-    isMetadataBased: false
+    useConfigFromMetadata: false
   };
 
   /**
@@ -143,7 +143,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   }
 
   useMetadata(): boolean {
-    return this.config.isMetadataBased && !!this.config.metadataProfileId;
+    return this.config.useConfigFromMetadata && !!this.config.metadataProfileId;
   }
 
   /**


### PR DESCRIPTION

Issue:
bumper based metadata doesn't work

Root cause:
studio is using config with different name

Fix:
change the config name from isMetadataBased to useConfigFromMetadata

Resolves [FEC-14915](https://kaltura.atlassian.net/browse/FEC-14915)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-14915]: https://kaltura.atlassian.net/browse/FEC-14915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ