### PR TITLE
fix(FEC-14940): Behavior cleanup for per entry bumper

### DIFF
--- a/src/bumper.js
+++ b/src/bumper.js
@@ -437,6 +437,8 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
       positionArr = [metadata.BumperPosition];
     } else if (typeof metadata.BumperPosition === 'string') {
       positionArr = metadata.BumperPosition.split(',').map(Number);
+    } else if (metadata.BumperPosition === undefined) {
+      positionArr = DEFAULT_POSITION;
     }
     if (positionArr) {
       this.config.position = positionArr;

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -370,6 +370,9 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
         }
       } else {
         this._state = BumperState.DONE;
+        if (this.player.paused) {
+          this.player.play();
+        }
       }
       this._metadataFetched = true;
     } catch (e) {
@@ -403,7 +406,15 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   }
 
   _isValidBumperMetadata(metadata: any): boolean {
-    const hasBumperUrl = metadata.BumperUrl?.trim().length > 0;
+    let hasBumperUrl = false;
+    if (metadata.BumperUrl) {
+      try {
+        new URL(metadata.BumperUrl);
+        hasBumperUrl = true;
+      } catch (e) {
+        hasBumperUrl = false;
+      }
+    }
     const position = metadata.BumperPosition;
     let hasValidPosition = false;
 
@@ -412,6 +423,8 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     } else if (typeof position === 'string') {
       const postionArr = position.split(',').map(Number);
       hasValidPosition = postionArr.length === 2 && postionArr[0] === BumperBreakType.PREROLL && postionArr[1] === BumperBreakType.POSTROLL;
+    } else if (position === undefined) {
+      hasValidPosition = true;
     }
 
     return hasBumperUrl && hasValidPosition;
@@ -422,10 +435,12 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     let positionArr;
     if (typeof metadata.BumperPosition === 'number') {
       positionArr = [metadata.BumperPosition];
-    } else {
+    } else if (typeof metadata.BumperPosition === 'string') {
       positionArr = metadata.BumperPosition.split(',').map(Number);
     }
-    this.config.position = positionArr;
+    if (positionArr) {
+      this.config.position = positionArr;
+    }
     this._adBreakPosition = this.config.position[0];
     if (metadata.BumperClickThroughUrl) {
       this.config.clickThroughUrl = metadata.BumperClickThroughUrl;


### PR DESCRIPTION
### Description of the Changes

In case of using bumper data from entry metadata:
url field is mandatory all others are optional.
if some optional fields are empty, need to use the default values from default config.
If one of the field is invalid banner is not displayed at all.

solves [FEC-14940](https://kaltura.atlassian.net/browse/FEC-14940)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-14940]: https://kaltura.atlassian.net/browse/FEC-14940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ