### PR TITLE
feat(FEC-14949): Add entryId configuration support to Logo, Watermark, Error Slate and Bumper plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Allow the player to display a short clip before main entry. (Channel id, Sponsor
 
 ### Configuration
 
-In order to enable the plugin you can give the folowing config parameters while either `url` or `entryId` is required to make the plugin work
+In order to enable the plugin you can give the following config parameters while either `url` or `entryId` is required to make the plugin work
 
 #### id
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PlayKit JS Bumper - plugin for the [PlayKit JS Player]
- 
+
 [![Build Status](https://github.com/kaltura/playkit-js-bumper/actions/workflows/run_canary_full_flow.yaml/badge.svg)](https://github.com/kaltura/playkit-js-bumper/actions/workflows/run_canary_full_flow.yaml)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![](https://img.shields.io/npm/v/@playkit-js/playkit-js-bumper/latest.svg)](https://www.npmjs.com/package/@playkit-js/playkit-js-bumper)
@@ -50,19 +50,19 @@ Finally, add the bundle as a script tag in your page, and initialize the player
 <!--PlayKit info plugin-->
 <div id="player-placeholder" style="height:360px; width:640px">
   <script type="text/javascript">
-    var playerContainer = document.querySelector("#player-placeholder");
-    var config = {
-     ...
-     targetId: 'player-placeholder',
-     plugins: {
-       "bumper": {
-			   "url": "<BUMPER URL>"
-			}
-     }
-     ...
-    };
-    var player = KalturaPlayer.setup(config);
-    player.loadMedia(...);
+     var playerContainer = document.querySelector("#player-placeholder");
+     var config = {
+      ...
+      targetId: 'player-placeholder',
+      plugins: {
+        "bumper": {
+       "url": "<BUMPER URL>"
+    }
+      }
+      ...
+     };
+     var player = KalturaPlayer.setup(config);
+     player.loadMedia(...);
   </script>
 </div>
 ```
@@ -72,19 +72,21 @@ Finally, add the bundle as a script tag in your page, and initialize the player
 The bumper plugin purpose is to give the application a way to display a short clip before/after the main entry playback
 Allow the player to display a short clip before main entry. (Channel id, Sponsored by and more)
 
-
 ### Configuration
 
-
-In order to enable the plugin you can give the folowing config parameters while `url` it the only "must" key to make the plugin work
+In order to enable the plugin you can give the folowing config parameters while either `url` or `entryId` is required to make the plugin work
 
 #### id
 
-default = '' - The bumper container div id 
+default = '' - The bumper container div id
 
-#### url 
+#### url
 
-the url of the bumber video
+the url of the bumper video (either `url` or `entryId` must be provided)
+
+#### entryId
+
+default = '' - The Kaltura entry ID of the bumper video. When set, the plugin will fetch the video sources from this entry and use them as the bumper instead of the configured `url`. If `entryId` is not set, the `url` config will be used.
 
 #### clickThroughUrl
 
@@ -92,7 +94,7 @@ url to a website that will be opened when clicking on the bumper screen
 
 #### position
 
-default [0] - bumper before video playback, it receives an array that configured wheter bumper will be shown on playback start, playback end or both =>  [0], [-1], [0, -1]
+default [0] - bumper before video playback, it receives an array that configured wheter bumper will be shown on playback start, playback end or both => [0], [-1], [0, -1]
 
 #### disableMediaPreload
 
@@ -109,6 +111,7 @@ plugins: {
        bumper: {
 		    id: '',
 		    url: '',
+		    entryId: '',
 		    clickThroughUrl: '',
 		    position: [],
 		    disableMediaPreload: false,
@@ -120,7 +123,6 @@ plugins: {
 ### Example:
 
 **[Bumper Plugin Example](https://codepen.io/giladna/pen/eYKmpxR)**
-
 
 ### Coding style tests
 
@@ -141,4 +143,3 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 ## License
 
 This project is licensed under the AGPL-3.0 License - see the [LICENSE](LICENSE) file for details
-

--- a/src/bumper-middleware.js
+++ b/src/bumper-middleware.js
@@ -44,7 +44,7 @@ class BumperMiddleware extends BaseMiddleware {
     ) {
       this._context.load();
     }
-    if (!(this._context.config.url && this._context.config.position.includes(BumperBreakType.PREROLL))) {
+    if (!((this._context.config.url || this._context.config.entryId) && this._context.config.position.includes(BumperBreakType.PREROLL))) {
       this._callNextLoad();
     }
   }
@@ -74,7 +74,7 @@ class BumperMiddleware extends BaseMiddleware {
         if (this._context._metadataPromise && !this._context._metadataFetched) {
           await this._context._metadataPromise;
         }
-        if (this._context.config.url && this._context.adBreakPosition === BumperBreakType.PREROLL) {
+        if ((this._context.config.url || this._context.config.entryId) && this._context.adBreakPosition === BumperBreakType.PREROLL) {
           // preroll bumper
           this._context.initBumperCompletedPromise();
           this._context.play();

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -674,7 +674,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     return this.config.url;
   }
 
-  async load(): void {
+  async load(): Promise<void> {
     if (this._metadataPromise && !this._metadataFetched) {
       await this._metadataPromise;
     }

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -7,6 +7,8 @@ import {BumperEngineDecorator} from './bumper-engine-decorator';
 import './assets/style.css';
 import {BumperEvents} from './events';
 import {MetadataLoader} from './providers/metadata-loader';
+import {FlavorAssetLoader} from './providers/flavor-asset-loader';
+import {FlavorUrlLoader} from './providers/flavor-url-loader';
 import {KalturaMetadata} from './providers/response-types/kaltura-metadata';
 import {XMLParser} from 'fast-xml-parser';
 
@@ -45,6 +47,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   static defaultConfig: Object = {
     id: '',
     url: '',
+    entryId: '',
     clickThroughUrl: '',
     position: DEFAULT_POSITION,
     disableMediaPreload: false,
@@ -159,15 +162,22 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
       this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
     }
     this._adBreak = true;
-    this.load();
-    this._hideElement(this._bumperCoverDiv);
-    const playPromise = this._videoElement.play();
-    if (playPromise) {
-      playPromise.catch(promiseError => {
+    this.load()
+      .then(() => {
+        this._hideElement(this._bumperCoverDiv);
+        const playPromise = this._videoElement.play();
+        if (playPromise) {
+          playPromise.catch(promiseError => {
+            this._adBreak = false;
+            this.player.dispatchEvent(new FakeEvent(EventType.AD_AUTOPLAY_FAILED, {error: promiseError}));
+          });
+        }
+      })
+      .catch(error => {
+        this.logger.error('Error loading bumper:', error);
         this._adBreak = false;
-        this.player.dispatchEvent(new FakeEvent(EventType.AD_AUTOPLAY_FAILED, {error: promiseError}));
+        this.player.dispatchEvent(new FakeEvent(EventType.AD_AUTOPLAY_FAILED, {error}));
       });
-    }
   }
 
   /**
@@ -228,7 +238,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
       this._metadataPromise = this.handleMetadataUpdate();
       await this._metadataPromise;
     }
-    if (this.config.url) {
+    if (this.config.url || this.config.entryId) {
       this.dispatchEvent(EventType.AD_MANIFEST_LOADED, {adBreaksPosition: [...this.config.position]});
     } else {
       this._state = BumperState.DONE;
@@ -405,16 +415,21 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     return kalturaMetadata;
   }
 
-  _isValidBumperMetadata(metadata: any): boolean {
+  _isValidUrl(url: string): boolean {
     let hasBumperUrl = false;
-    if (metadata.BumperUrl) {
+    if (url) {
       try {
-        new URL(metadata.BumperUrl);
+        new URL(url);
         hasBumperUrl = true;
       } catch (e) {
         hasBumperUrl = false;
       }
     }
+    return hasBumperUrl;
+  }
+  _isValidBumperMetadata(metadata: any): boolean {
+    const hasBumperUrl = this._isValidUrl(metadata.BumperUrl);
+    const hasEntryId = typeof metadata.BumperEntryId === 'string';
     const position = metadata.BumperPosition;
     let hasValidPosition = false;
 
@@ -427,11 +442,18 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
       hasValidPosition = true;
     }
 
-    return hasBumperUrl && hasValidPosition;
+    return (hasBumperUrl || hasEntryId) && hasValidPosition;
   }
 
   _updateConfigFromMetadata(metadata: any): void {
-    this.config.url = metadata.BumperUrl;
+    if (this._isValidUrl(metadata.BumperUrl)) {
+      this.config.url = metadata.BumperUrl;
+    }
+    if (typeof metadata.BumperEntryId === 'string') {
+      this.config.entryId = metadata.BumperEntryId;
+    } else {
+      this.config.entryId = '';
+    }
     let positionArr;
     if (typeof metadata.BumperPosition === 'number') {
       positionArr = [metadata.BumperPosition];
@@ -625,6 +647,33 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     Utils.Dom.removeAttribute(this._bumperClickThroughDiv, 'href');
   }
 
+  async _getBumperUrl(): Promise<string> {
+    if (this.config.entryId) {
+      try {
+        const ks = this.player.config.session?.ks || '';
+        const assetData: Map<string, any> = await this.player.provider.doRequest(
+          [{loader: FlavorAssetLoader, params: {entryId: this.config.entryId}}],
+          ks
+        );
+        if (assetData.has(FlavorAssetLoader.id)) {
+          const highestBitrateAsset = assetData.get(FlavorAssetLoader.id)?.response?.flavorAsset;
+          const urlData: Map<string, any> = await this.player.provider.doRequest(
+            [{loader: FlavorUrlLoader, params: {flavorAsset: highestBitrateAsset}}],
+            ks
+          );
+          if (urlData.has(FlavorUrlLoader.id)) {
+            const url = urlData.get(FlavorUrlLoader.id)?.response?.url || '';
+            return url;
+          }
+        }
+      } catch (e) {
+        this.logger.error('Failed to load bumper from entryId:', e);
+        return this.config.url;
+      }
+    }
+    return this.config.url;
+  }
+
   async load(): void {
     if (this._metadataPromise && !this._metadataFetched) {
       await this._metadataPromise;
@@ -636,6 +685,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
       if (this._adBreak) {
         this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
       }
+      const bumperUrl = await this._getBumperUrl();
       this.eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => this._onLoadedData());
       if (this.playOnMainVideoTag()) {
         this.logger.debug('Switch source to bumper url');
@@ -645,9 +695,9 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
         this._selectedAudioTrack = this.player.getActiveTracks().audio;
         this._selectedTextTrack = this.player.getActiveTracks().text;
         this._selectedPlaybackRate = this.player.playbackRate;
-        this.player.getVideoElement().src = this.config.url;
+        this.player.getVideoElement().src = bumperUrl;
       } else {
-        this._bumperVideoElement.src = this.config.url;
+        this._bumperVideoElement.src = bumperUrl;
         this._bumperVideoElement.setAttribute('playsinline', '');
       }
     }

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -84,6 +84,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   _validData: Boolean;
   _metadataFetched: Boolean;
   _metadataPromise: Promise<void> | null;
+  _bumperSrc: string;
 
   /**
    * @constructor
@@ -344,6 +345,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     this._validData = true;
     this._metadataFetched = false;
     this._metadataPromise = null;
+    this._bumperSrc = '';
   }
 
   _setClickThroughUrl() {
@@ -374,13 +376,14 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
         } else {
           this._state = BumperState.DONE;
           this._bumperCompletedPromise = Promise.resolve();
-          if (this.player.paused) {
+          if (this.player.paused && this.player.config.playback.autoplay) {
             this.player.play();
           }
         }
       } else {
         this._state = BumperState.DONE;
-        if (this.player.paused) {
+        this._bumperCompletedPromise = Promise.resolve();
+        if (this.player.paused && this.player.config.playback.autoplay) {
           this.player.play();
         }
       }
@@ -428,8 +431,10 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     return hasBumperUrl;
   }
   _isValidBumperMetadata(metadata: any): boolean {
-    const hasBumperUrl = this._isValidUrl(metadata.BumperUrl);
-    const hasEntryId = typeof metadata.BumperEntryId === 'string';
+    const isBumperUrlValid = this._isValidUrl(metadata.BumperUrl);
+    const isBumperEntryIdValid = typeof metadata.BumperEntryId === 'string';
+    const hasBumperUrl = !!metadata.BumperUrl;
+    const hasEntryId = !!metadata.BumperEntryId;
     const position = metadata.BumperPosition;
     let hasValidPosition = false;
 
@@ -442,12 +447,23 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
       hasValidPosition = true;
     }
 
-    return (hasBumperUrl || hasEntryId) && hasValidPosition;
+    if (hasBumperUrl && hasEntryId) {
+      return isBumperUrlValid && isBumperEntryIdValid && hasValidPosition;
+    }
+    if (hasBumperUrl) {
+      return isBumperUrlValid && hasValidPosition;
+    }
+    if (hasEntryId) {
+      return isBumperEntryIdValid && hasValidPosition;
+    }
+    return false;
   }
 
   _updateConfigFromMetadata(metadata: any): void {
     if (this._isValidUrl(metadata.BumperUrl)) {
       this.config.url = metadata.BumperUrl;
+    } else {
+      this.config.url = '';
     }
     if (typeof metadata.BumperEntryId === 'string') {
       this.config.entryId = metadata.BumperEntryId;
@@ -593,7 +609,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   }
 
   _maybeSwitchToContent(): void {
-    if (this._contentSrc && this.player.getVideoElement().src === this.config.url && !this.player.config.playback.playAdsWithMSE) {
+    if (this._contentSrc && this.player.getVideoElement().src === this._bumperSrc && !this.player.config.playback.playAdsWithMSE) {
       this.logger.debug('Switch source to content url');
       this.eventManager.listenOnce(this._engine, EventType.PLAYING, () => {
         this.player.selectTrack(this._selectedAudioTrack);
@@ -685,7 +701,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
       if (this._adBreak) {
         this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
       }
-      const bumperUrl = await this._getBumperUrl();
+      this._bumperSrc = await this._getBumperUrl();
       this.eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => this._onLoadedData());
       if (this.playOnMainVideoTag()) {
         this.logger.debug('Switch source to bumper url');
@@ -695,9 +711,9 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
         this._selectedAudioTrack = this.player.getActiveTracks().audio;
         this._selectedTextTrack = this.player.getActiveTracks().text;
         this._selectedPlaybackRate = this.player.playbackRate;
-        this.player.getVideoElement().src = bumperUrl;
+        this.player.getVideoElement().src = this._bumperSrc;
       } else {
-        this._bumperVideoElement.src = bumperUrl;
+        this._bumperVideoElement.src = this._bumperSrc;
         this._bumperVideoElement.setAttribute('playsinline', '');
       }
     }
@@ -706,7 +722,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
   _getAd(): Ad {
     const adOptions: PKAdOptions = {
       system: '',
-      url: this.config.url,
+      url: this._bumperSrc || this.config.url,
       contentType: '',
       title: '',
       position: 1,
@@ -742,6 +758,7 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
     this._hideElement(this._bumperContainerDiv);
     this._resetClickThroughElement();
     Utils.Dom.removeAttribute(this._bumperVideoElement, 'src');
+    this._bumperSrc = '';
     this._initMembers();
     if (this.useMetadata()) {
       this.config = {...this._initialConfig};

--- a/src/bumper.js
+++ b/src/bumper.js
@@ -157,13 +157,13 @@ class Bumper extends BasePlugin implements IMiddlewareProvider, IAdsControllerPr
    * @memberof Bumper
    */
   play(): void {
-    //preload
-    if ([BumperState.LOADING, BumperState.LOADED].includes(this._bumperState)) {
-      this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
-    }
     this._adBreak = true;
     this.load()
       .then(() => {
+        //preload
+        if ([BumperState.LOADING, BumperState.LOADED].includes(this._bumperState)) {
+          this.dispatchEvent(EventType.AD_BREAK_START, {adBreak: this._getAdBreak()});
+        }
         this._hideElement(this._bumperCoverDiv);
         const playPromise = this._videoElement.play();
         if (playPromise) {

--- a/src/providers/flavor-asset-loader.js
+++ b/src/providers/flavor-asset-loader.js
@@ -51,7 +51,9 @@ export class FlavorAssetLoader implements ILoader {
     if (response && response.length > 0) {
       const flavorAssetListResponse = new KalturaFlavorAssetListResponse(response[0]?.data);
       if (flavorAssetListResponse.data && flavorAssetListResponse.data.length > 0) {
-        const highestBitrateAsset = [...flavorAssetListResponse.data].sort((a, b) => (b.bitrate || 0) - (a.bitrate || 0))[0];
+        const highestBitrateAsset = flavorAssetListResponse.data.reduce((highest, asset) =>
+          (asset.bitrate || 0) > (highest.bitrate || 0) ? asset : highest
+        );
         this._response.flavorAsset = highestBitrateAsset;
       }
     }

--- a/src/providers/flavor-asset-loader.js
+++ b/src/providers/flavor-asset-loader.js
@@ -1,0 +1,67 @@
+// @flow
+import {RequestBuilder} from '@playkit-js/playkit-js-providers/ovp-provider';
+import {ILoader} from '@playkit-js/playkit-js-providers/ovp-provider';
+import {KalturaFlavorAssetListResponse} from './response-types/kaltura-flavor-asset-list-response';
+
+interface FlavorAssetLoaderParams {
+  entryId: string;
+}
+
+type FlavorAssetResponse = {
+  flavorAsset: any
+};
+
+export class FlavorAssetLoader implements ILoader {
+  _entryId: string;
+  _requests: RequestBuilder[] = [];
+  _response: FlavorAssetResponse = {
+    flavorAsset: null
+  };
+
+  static get id(): string {
+    return 'flavorList';
+  }
+
+  constructor({entryId}: FlavorAssetLoaderParams) {
+    this._entryId = entryId;
+    const headers: Map<string, string> = new Map();
+
+    const flavorAssetListRequest = new RequestBuilder(headers);
+    flavorAssetListRequest.service = 'flavorasset';
+    flavorAssetListRequest.action = 'list';
+    flavorAssetListRequest.params = {
+      filter: {
+        objectType: 'KalturaAssetFilter',
+        entryIdEqual: this._entryId
+      }
+    };
+    this._requests.push(flavorAssetListRequest);
+  }
+
+  set requests(requests: any[]) {
+    this._requests = requests;
+  }
+
+  get requests(): any[] {
+    return this._requests;
+  }
+
+  set response(response: any) {
+    // Response is the flavor asset list
+    if (response && response.length > 0) {
+      const flavorAssetListResponse = new KalturaFlavorAssetListResponse(response[0]?.data);
+      if (flavorAssetListResponse.data && flavorAssetListResponse.data.length > 0) {
+        const highestBitrateAsset = [...flavorAssetListResponse.data].sort((a, b) => (b.bitrate || 0) - (a.bitrate || 0))[0];
+        this._response.flavorAsset = highestBitrateAsset;
+      }
+    }
+  }
+
+  get response(): any {
+    return this._response;
+  }
+
+  isValid(): boolean {
+    return Boolean(this._entryId);
+  }
+}

--- a/src/providers/flavor-url-loader.js
+++ b/src/providers/flavor-url-loader.js
@@ -1,0 +1,56 @@
+// @flow
+import {RequestBuilder} from '@playkit-js/playkit-js-providers/ovp-provider';
+import {ILoader} from '@playkit-js/playkit-js-providers/ovp-provider';
+
+interface FlavorUrlLoaderParams {
+  flavorAsset: any;
+}
+
+type FlavorUrlResponse = {
+  url: string
+};
+
+export class FlavorUrlLoader implements ILoader {
+  _flavorAsset: any;
+  _requests: RequestBuilder[] = [];
+  _response: FlavorUrlResponse = {
+    url: ''
+  };
+
+  static get id(): string {
+    return 'flavorUrl';
+  }
+
+  constructor({flavorAsset}: FlavorUrlLoaderParams) {
+    this._flavorAsset = flavorAsset;
+    const headers: Map<string, string> = new Map();
+
+    const request = new RequestBuilder(headers);
+    request.service = 'flavorasset';
+    request.action = 'getUrl';
+    request.params = {
+      id: this._flavorAsset.id
+    };
+    this._requests.push(request);
+  }
+
+  set requests(requests: any[]) {
+    this._requests = requests;
+  }
+
+  get requests(): any[] {
+    return this._requests;
+  }
+
+  set response(response: any) {
+    this._response.url = response[0]?.data || '';
+  }
+
+  get response(): any {
+    return this._response;
+  }
+
+  isValid(): boolean {
+    return true;
+  }
+}

--- a/src/providers/response-types/kaltura-flavor-asset-list-response.js
+++ b/src/providers/response-types/kaltura-flavor-asset-list-response.js
@@ -1,0 +1,20 @@
+// @flow
+import {ResponseTypes} from '@playkit-js/playkit-js-providers/ovp-provider';
+import {KalturaFlavorAsset} from './kaltura-flavor-asset';
+
+const {BaseServiceResult} = ResponseTypes;
+
+export class KalturaFlavorAssetListResponse extends BaseServiceResult {
+  totalCount: number;
+  data: KalturaFlavorAsset[] = [];
+
+  constructor(responseObj: any) {
+    super(responseObj);
+    if (!this.hasError && responseObj) {
+      this.totalCount = responseObj.totalCount || 0;
+      if (responseObj.objects && Array.isArray(responseObj.objects)) {
+        this.data = responseObj.objects.map((obj: any) => new KalturaFlavorAsset(obj));
+      }
+    }
+  }
+}

--- a/src/providers/response-types/kaltura-flavor-asset.js
+++ b/src/providers/response-types/kaltura-flavor-asset.js
@@ -7,13 +7,7 @@ export class KalturaFlavorAsset extends BaseServiceResult {
   id: string;
   entryId: string;
   status: string;
-  width: ?number;
-  height: ?number;
   bitrate: ?number;
-  frameRate: ?number;
-  isOriginal: boolean;
-  createdAt: number;
-  updatedAt: number;
   url: ?string;
 
   constructor(responseObj: any) {
@@ -22,13 +16,7 @@ export class KalturaFlavorAsset extends BaseServiceResult {
       this.id = responseObj.id;
       this.entryId = responseObj.entryId;
       this.status = responseObj.status;
-      this.width = responseObj.width;
-      this.height = responseObj.height;
       this.bitrate = responseObj.bitrate;
-      this.frameRate = responseObj.frameRate;
-      this.isOriginal = responseObj.isOriginal;
-      this.createdAt = responseObj.createdAt;
-      this.updatedAt = responseObj.updatedAt;
     }
   }
 }

--- a/src/providers/response-types/kaltura-flavor-asset.js
+++ b/src/providers/response-types/kaltura-flavor-asset.js
@@ -1,0 +1,34 @@
+// @flow
+import {ResponseTypes} from '@playkit-js/playkit-js-providers/ovp-provider';
+
+const {BaseServiceResult} = ResponseTypes;
+
+export class KalturaFlavorAsset extends BaseServiceResult {
+  id: string;
+  entryId: string;
+  status: string;
+  width: ?number;
+  height: ?number;
+  bitrate: ?number;
+  frameRate: ?number;
+  isOriginal: boolean;
+  createdAt: number;
+  updatedAt: number;
+  url: ?string;
+
+  constructor(responseObj: any) {
+    super(responseObj);
+    if (!this.hasError && responseObj) {
+      this.id = responseObj.id;
+      this.entryId = responseObj.entryId;
+      this.status = responseObj.status;
+      this.width = responseObj.width;
+      this.height = responseObj.height;
+      this.bitrate = responseObj.bitrate;
+      this.frameRate = responseObj.frameRate;
+      this.isOriginal = responseObj.isOriginal;
+      this.createdAt = responseObj.createdAt;
+      this.updatedAt = responseObj.updatedAt;
+    }
+  }
+}

--- a/test/src/bumper.spec.js
+++ b/test/src/bumper.spec.js
@@ -1239,5 +1239,57 @@ describe('Bumper', () => {
       player.configure({plugins: {bumper: {clickThroughUrl: 'some/updated/url'}}});
       player.plugins.bumper._bumperClickThroughDiv.href.endsWith('some/updated/url').should.be.true;
     });
+
+    it('Should load bumper from entryId and fire correct event sequence', done => {
+      let eventSequence = [];
+      eventManager.listenOnce(player, player.Event.AD_MANIFEST_LOADED, () => {
+        eventSequence.push('AD_MANIFEST_LOADED');
+        eventManager.listenOnce(player, player.Event.AD_BREAK_START, () => {
+          eventSequence.push('AD_BREAK_START');
+          eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
+            try {
+              eventSequence[0].should.equal('AD_MANIFEST_LOADED');
+              eventSequence[1].should.equal('AD_BREAK_START');
+              done();
+            } catch (e) {
+              done(e);
+            }
+          });
+        });
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            entryId: '0_w9ud0vch',
+            position: [BumperBreakType.PREROLL]
+          }
+        },
+        sources
+      });
+      player.play();
+    });
+
+    it('Should fallback to URL when entryId fails', done => {
+      eventManager.listenOnce(player, player.Event.AD_MANIFEST_LOADED, () => {
+        eventManager.listenOnce(player, player.Event.AD_BREAK_START, () => {
+          eventManager.listenOnce(player, player.Event.AD_COMPLETED, () => {
+            eventManager.listenOnce(player, player.Event.AD_BREAK_END, () => {
+              done();
+            });
+          });
+        });
+      });
+      player.configure({
+        plugins: {
+          bumper: {
+            entryId: 'invalid_entry_id',
+            url: BUMPER_URL,
+            position: [BumperBreakType.PREROLL]
+          }
+        },
+        sources
+      });
+      player.play();
+    });
   });
 });


### PR DESCRIPTION
### Description of the Changes

Adding support for entryId configuration in order to play entryId as a bumper.

using the flavor with the highest bitrate to get the mp4 url.
If both entryId and url are set prefer entryId.
If entryId can't be played (id not valid, acp and etc) fallback to url
when using bumper data from entry metadata, if entryId is not valid and url is not set - show nothing.

solves [FEC-14949](https://kaltura.atlassian.net/browse/FEC-14949)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-14949]: https://kaltura.atlassian.net/browse/FEC-14949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ